### PR TITLE
Resolved links in essentials .md files

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -77,6 +77,12 @@ module.exports = {
             path: '/how-tos/',
             children: [
               {
+                title: 'Quick start',
+                sidebarDepth: 1,
+                collapsable: false,
+                children: ['/how-tos/command-line-quick-start']
+              },
+              {
                 title: 'Customize your install',
                 sidebarDepth: 1,
                 collapsable: false,

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -95,11 +95,11 @@ module.exports = {
                 children: [
                   [
                     'https://github.com/ipfs/js-ipfs/tree/master/examples/ipfs-101',
-                    'Spawn a node (JS)'
+                    'Use js-ipfs as a library'
                   ],
                   [
                     'https://github.com/ipfs/go-ipfs/tree/master/docs/examples/go-ipfs-as-a-library/README.md',
-                    'Spawn a node (Go)'
+                    'Use go-ipfs as a library'
                   ],
                   '/how-tos/work-with-blocks',
                   '/how-tos/pin-files',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -55,6 +55,7 @@ module.exports = {
                 sidebarDepth: 1,
                 collapsable: false,
                 children: [
+                  '/essentials/dht',
                   '/essentials/merkle-dags',
                   '/essentials/bitswap',
                   '/essentials/ipld',

--- a/docs/essentials/bitswap.md
+++ b/docs/essentials/bitswap.md
@@ -3,10 +3,6 @@ title: Bitswap
 sidebarDepth: 0
 ---
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
-
 # Bitswap
 
 ## Sorry, this content hasn't touched down yet.

--- a/docs/essentials/content-addressing.md
+++ b/docs/essentials/content-addressing.md
@@ -33,6 +33,6 @@ These leading identifiers also provide forward-compatibility, supporting differe
 
 You can use the first few bytes of the CID to interpret the remainder of the content address and know how to decode the content after it's fetched from IPFS. For more details, check out the [CID specification](https://github.com/ipld/cid). It includes a [decoding algorithm](https://github.com/ipld/cid/blob/ef1b2002394b15b1e6c26c30545fd485f2c4c138/README.md#decoding-algorithm) and links to existing software implementations for decoding CIDs.
 
-## Explore CIDs for yourself
+## CID Inspector
 
-Want to pull apart a specific CID's multibase, multicodec, or multihash info? You can use the [CID Inspector](https://cid.ipfs.io/#QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU) or the [CID Info panel in IPLD Explorer](https://explore.ipld.io/#/explore/QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU) (both links launch using a sample CID) for an interactive breakdown of differently-formatted CIDs.
+It's easy to explore a CID for yourself. Want to pull apart a specific CID's multibase, multicodec, or multihash info? You can use the [CID Inspector](https://cid.ipfs.io/#QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU) or the [CID Info panel in IPLD Explorer](https://explore.ipld.io/#/explore/QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU) (both links launch using a sample CID) for an interactive breakdown of differently-formatted CIDs.

--- a/docs/essentials/content-addressing.md
+++ b/docs/essentials/content-addressing.md
@@ -4,20 +4,16 @@ title: Content addressing
 
 # Content addressing and CIDs
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
-
 A _content identifier_, or CID, is a label used to point to material in IPFS. It doesn't indicate _where_ the content is stored, but it forms a kind of address based on the content itself. CIDs are short, regardless of the size of their underlying content.
 
-CIDs are based on the content’s [cryptographic hash](./hashes.md). That means:
+CIDs are based on the content’s [cryptographic hash](/essentials/hashing/). That means:
 
 - Any difference in content will produce a different CID and
 - The same piece of content added to two different IPFS nodes using the same settings will produce _exactly the same CID_.
 
 ## CID formats
 
-CIDs can take a few different forms with different encoding bases or CID versions. Many of the existing IPFS tools still generate v0 CIDs, although the `files` ([MFS](./mfs.md)) and `object` operations now use CIDv1 by default.
+CIDs can take a few different forms with different encoding bases or CID versions. Many of the existing IPFS tools still generate v0 CIDs, although the `files` ([Mutable File System](/essentials/file-systems/#mutable-file-system-mfs)) and `object` operations now use CIDv1 by default.
 
 ### Version 0
 

--- a/docs/essentials/dht.md
+++ b/docs/essentials/dht.md
@@ -1,0 +1,87 @@
+---
+title: Distributed Hash Tables (DHTs)
+---
+
+# Distributed Hash Tables (DHTs)
+
+## What is a DHT?
+
+[Distributed Hash Tables](https://en.wikipedia.org/wiki/Distributed_hash_table) (DHTs) are distributed key-value stores where keys are [cryptographic hashes](/essentials/hashing).
+
+DHTs are, by definition, distributed. Each "peer" (or "node") is responsible for a subset of the DHT.
+When a peer receives a request, it either answers it, or the request is passed to another peer until a peer that can answer it is found.
+Depending on the implementation, a request not answered by the first node contacted can be:
+
+- forwarded from peer to peer, with the last peer contacting the requesting peer
+- forwarded from peer to peer, with the answer forwarded following the same path
+- answered with the contact information of a node that has better chances to be able to answer. **IPFS uses this strategy.**
+
+DHTs' decentralization provides advantages compared to a traditional key-value store, including:
+
+- _scalability_, since a request for a hash of length _n_ takes at most _log2(n)_ steps to resolve.
+- _fault tolerance_ via redundancy, so that lookups are possible even if peers unexpectedly leave or join the DHT. Additionally, requests can be addressed to any peer if another peer is slow or unavailable.
+- _load balancing_, since requests are made to different nodes and no unique peers process all the requests.
+
+## How does the IPFS DHT work?
+
+### Peer IDs
+
+Each peer has a `peerID`, which is a hash with the same length _n_ as the DHT keys.
+
+### Buckets
+
+A subset of the DHT maintained by a peer is called a 'bucket'.
+A bucket maps to hashes with the same prefix as the `peerID`, up to _m_ bits. There are 2^m buckets. Each bucket maps for 2^(n-m) hashes.
+
+For example, if _m_=2^16 and we use hexadecimal encoding (four bits per displayed character), the peer with `peerID` 'ABCDEF12345' maintains mapping for hashes starting with 'ABCD'.
+Some hashes falling into this bucket would be *ABCD*38E56, *ABCD*09CBA or *ABCD*17ABB, just as examples.
+
+The size of a bucket is related to the size of the prefix. The longer the prefix, the fewer hashes each peer has to manage, and the more peers are needed.
+Several peers can be in charge of the same bucket if they have the same prefix.
+
+In most DHTs, including [IPFS's Kademlia implementation](https://github.com/libp2p/specs/blob/8b89dc2521b48bf6edab7c93e8129156a7f5f02c/kad-dht/README.md), the size of the buckets (and the size of the prefix), are dynamic.
+
+### Peer lists
+
+Peers also keep a connection to other peers in order to forward requests if the requested hash is not in their own bucket.
+
+If hashes are of length n, a peer will keep n-1 lists of peers:
+
+- the first list contains peers whose IDs have a different first bit.
+- the second list contains peers whose IDs have first bits identical to its own, but a different second bit
+- ...
+- the m-th list contains peers whose IDs have their first m-1 bits identical, but a different m-th bit
+- ...
+
+The higher m is, the harder it is to find peers that have the same ID up to m bits. The lists of "closest" peers typically remains empty.
+"Close" here is defined as the XOR distance, so the longer the prefix they share, the closer they are.
+Lists also have a maximum of entries (k) — otherwise the first lists would contain half the network, then a fourth of the network, and so on.
+
+### Using the DHT
+
+When a peer receives a lookup request, it will either answer with a value if it falls into its own bucket, or answer with the contacting information (IP+port, `peerID`, etc.) of a closer peer. The requesting peer can then send its request to this closer peer. The process goes on until a peer is able to answer it.
+A request for a hash of length n will take at maximum log2(n) steps, or even log2m(n).
+
+### Keys and hashes
+
+In IPFS's Kademlia DHT, keys are SHA256 hashes.
+[PeerIDs](https://docs.libp2p.io/concepts/peer-id/) are those of [libp2p](https://libp2p.io/), the networking library used by IPFS.
+
+We use the DHT to look up two types of objects, both represented by SHA256 hashes:
+
+- [Content IDs](/essentials/content-addressing) of the data added to IPFS. A lookup of this value will give the `peerID`s of the peers having this immutable content.
+- [IPNS records](/essentials/ipns). A lookup will give the last Content ID associated with this IPNS address, enabling the routing of mutable content.
+
+Consequently, IPFS's DHT is one of the ways to achieve mutable and immutable [content routing](https://docs.libp2p.io/concepts/content-routing/). It's currently the only one [implemented](https://libp2p.io/implementations/#peer-routing).
+
+You can learn more in the [libp2p Kademlia DHT specification](https://github.com/libp2p/specs/blob/8b89dc2521b48bf6edab7c93e8129156a7f5f02c/kad-dht/README.md).
+
+## Usage
+
+### Adding an entry
+
+Adding a blob of data to IPFS is the equivalent of advertising that you have it. Since DHT is the only content routing implemented, you can just use:
+`ipfs add myData`
+IPFS will automatically chunk your data and add a mapping on the DHT between the Content ID and your `peerID`. Note that there can be other `peerID`s already mapped to that value, so you will be added to the list. Also note that if the provided data is bigger than 124KB, it will be chunked into "blocks", and both those blocks and the overall data will be mapped.
+
+You can publish an IPNS record using [`ipfs.name.publish`](/essentials/ipns).

--- a/docs/essentials/dht.md
+++ b/docs/essentials/dht.md
@@ -22,7 +22,9 @@ DHTs' decentralization provides advantages compared to a traditional key-value s
 - _fault tolerance_ via redundancy, so that lookups are possible even if peers unexpectedly leave or join the DHT. Additionally, requests can be addressed to any peer if another peer is slow or unavailable.
 - _load balancing_, since requests are made to different nodes and no unique peers process all the requests.
 
-## How does the IPFS DHT work?
+## DHTs on IPFS
+
+Now that we know what DHTs are, let's take a look specifically at how DHTs work on IPFS.
 
 ### Peer IDs
 

--- a/docs/essentials/dnslink.md
+++ b/docs/essentials/dnslink.md
@@ -4,12 +4,6 @@ title: DNSLink
 
 # DNSLink
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
-
-**NOTE: The info below is a quick guide to DNSLink. For a more complete guide, including tutorials, usage examples and FAQs, check out [dnslink.io](http://dnslink.io/).**
-
 ## About DNSLink
 
 DNSLink uses [DNS TXT](https://en.wikipedia.org/wiki/TXT_record) records to map
@@ -19,7 +13,7 @@ object in IPFS (remember that an IPFS object’s address changes if you modify
 the object). Because DNSLink uses DNS records, the names it produces are also
 usually easy to type and read.
 
-A DNSLink address looks like an [IPNS](/guides/concepts/ipns) address, but it
+A DNSLink address looks like an [IPNS](/essentials/ipns/) address, but it
 uses a domain name in place of a hashed public key:
 
 ```
@@ -45,19 +39,19 @@ $ dig +noall +answer TXT ipfs.io
 ipfs.io.		59	IN	TXT	"dnslink=/ipfs/QmYNQJoKGNHTpPxCBPh9KkDpaExgd2duMa3aF6ytMpHdao"
 ```
 
-Based on that, this address:
+Based on that, this address ...
 
 ```
 /ipns/ipfs.io/media/
 ```
 
-Will get you this block:
+... will get you this block:
 
 ```
 /ipfs/QmYNQJoKGNHTpPxCBPh9KkDpaExgd2duMa3aF6ytMpHdao/media/
 ```
 
-## Publishing via a Subdomain
+## Publishing via subdomain
 
 You can also publish DNSLink records using a special subdomain named `_dnslink`. This is useful when you want to improve the security of an automated setup or delegate control over your DNSLink records to a third-party without giving away full control over the original DNS zone.
 
@@ -68,3 +62,7 @@ because a TXT record exists for `_dnslink.docs.ipfs.io`:
 $ dig +noall +answer TXT _dnslink.docs.ipfs.io
 _dnslink.docs.ipfs.io.  34  IN  TXT "dnslink=/ipfs/QmeveuwF5wWBSgUXLG6p1oxF3GKkgjEnhA6AAwHUoVsx6E"
 ```
+
+## Further resources
+
+For a complete guide to DNSLink — including tutorials, usage examples and FAQs — check out [dnslink.io](http://dnslink.io/).

--- a/docs/essentials/faq.md
+++ b/docs/essentials/faq.md
@@ -4,37 +4,31 @@ title: FAQ
 
 # Frequently Asked Questions
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
-
-Content to come. Let's use H2s for topic areas, rather than individual questions, so this doesn't get too long in the left nav.
-
 ## What is IPFS?
 
-IPFS stands for the InterPlanetary File System - a peer-to-peer network for storing and accessing files, websites, applications, and data in a distributed file system.
+IPFS stands for the InterPlanetary File System — a peer-to-peer network for storing and accessing files, websites, applications, and data in a distributed file system.
 
-To learn more, see [this guide on “what is IPFS?”](introduction/overview.md).
+To learn more, see the [“what is IPFS?”](/essentials/what-is-ipfs) guide.
 
-## IPFS in the wild
+## IPFS in action
 
 ### Where can I see IPFS in action today?
 
-https://awesome.ipfs.io/ is a good starting point to see the variety of projects using IPFS today. You can also add your own project here: https://github.com/ipfs/awesome-ipfs
+[Awesome IPFS](https://awesome.ipfs.io/) is a good starting point to see the wide variety of projects that are using IPFS today. If you've got your own awesome IPFS project, please add it to the [Awesome IPFS repo](https://github.com/ipfs/awesome-ipfs) so the rest of the world can see it!
 
 ## Getting started
 
 ### How do I get started with IPFS?
 
-For installing and initializing IPFS, check out [this getting started guide](introduction/usage.md).
+The quickest way to get IPFS up and running on your machine is by installing [IPFS Desktop](https://github.com/ipfs-shipyard/ipfs-desktop), the easy-to-use app that enables you to run an IPFS node on your computer without having to bother with terminal commands.
+
+For installing and initializing IPFS from the command line, check out the [command-line quick start](/how-tos/command-line-quick-start/) guide.
 
 ## Contributing to IPFS
 
 ### How do I start contributing to IPFS?
 
-A great way to help out right now is to run a node or two and report any issues you have, ask questions about everything that isn’t obvious (to help us write better documentation) and if you’re feeling really helpful, write up short guides on anything you think might be useful. If you want to contribute code to either of the core IPFS implementations, please review the [Community Contributing Guidelines](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md).
-
-Stop in and say hi on IRC at #ipfs on freenode too if you feel like chatting.
+There are a lot of ways you can contribute to IPFS, whether you're interested in helping with either of the core implementations, applications like IPFS Desktop, writing or editing documentation, doing UX, or whatever you enjoy working on. [Get all the details on where to get started here.](/project/contribute/)
 
 ## IPFS and Filecoin
 
@@ -44,14 +38,14 @@ Filecoin and IPFS are two separate, complementary protocols, both created by Pro
 
 In short: IPFS addresses and moves content; while Filecoin is an incentive layer to persist data.
 
-These components are separable - you can use one without the other, and IPFS already supports more self-organized or altruistic forms of data persistance via tools like [IPFS Cluster](https://cluster.ipfs.io/). Compatibility between IPFS and Filecoin is intended to be as seamless as possible, but we expect it to evolve over time. You can view the [draft spec for IPFS<>Filecoin Interoperability](https://github.com/filecoin-project/specs/issues/143) and [ideas for future improvements](https://github.com/filecoin-project/specs/issues/144) to learn more.
+These components are separable - you can use one without the other, and IPFS already supports more self-organized or altruistic forms of data persistance via tools like [IPFS Cluster](https://cluster.ipfs.io/). Compatibility between IPFS and Filecoin is intended to be as seamless as possible, but we expect it to evolve over time. You can view the [draft spec for IPFS-Filecoin Interoperability](https://github.com/filecoin-project/specs/issues/143) and [ideas for future improvements](https://github.com/filecoin-project/specs/issues/144) to learn more.
 
 ## IPFS and Protocol Labs
 
 ### How are the IPFS Project and Protocol Labs related?
 
-IPFS is an Open Source Project and Community with over 4K contributors around the world from many different projects. There are a number of core IPFS team members who are sponsored to work on the project by [Protocol Labs](https://protocol.ai/) - a startup that supports development on many related protocols like libp2p and Filecoin as well, with the aim of making the internet more capable and resilient. However the vast majority of developers in the IPFS community and ecosystem are supported by other organisations or individual OSS contributions.
+IPFS is an open source project, with a community of more than four thousand contributors around the world from many different projects. There are also core IPFS team members who are sponsored to work on the project by [Protocol Labs](https://protocol.ai/) — a startup that also supports development on many related protocols, such as libp2p and Filecoin, with the aim of making the internet more capable and resilient. However, the vast majority of developers in the IPFS community and ecosystem are supported by other organizations, or are individual OSS contributors.
 
 ## Don't see your question?
 
-You can see answers to past questions here: https://discuss.ipfs.io/c/help/Old-FAQ - If you don’t see your question, feel free to ask it too!
+We're working on expanding this FAQ with more content, including questions from the original-generation [IPFS forums](https://discuss.ipfs.io/c/help/Old-FAQ), so please watch this space! However, if you don’t see your question, please [ask in the forums](https://discuss.ipfs.io/) so you can get the answers you need and make us aware of new FAQ items.

--- a/docs/essentials/file-systems.md
+++ b/docs/essentials/file-systems.md
@@ -4,9 +4,12 @@ title: File systems
 
 # File systems and IPFS
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
+Working with files in IPFS can be a little different than you're used to for several different reasons:
+
+- Content addressing means that when files change, their addresses change, too
+- Files may be too big to fit in a single block, so they need metadata to keep blocks together
+
+MFS and UnixFS can help you address these new ways of thinking of files.
 
 ## Mutable File System (MFS)
 
@@ -24,8 +27,6 @@ This video also provides a good overview of MFS:
 
 A file in IPFS isn’t just content. It might be too big to fit in a single block, so it needs metadata to link all its blocks together. It might be a symlink or a directory, so it needs metadata to link to other files. UnixFS is the data format used to represent files and all their links and metadata in IPFS, and is loosely based on how files work in Unix. When you add a _file_ to IPFS, you are creating a block (or a tree of blocks) in the UnixFS format.
 
-UnixFS is a [protocol-buffers](https://developers.google.com/protocol-buffers/)-based format. You can find the definitions for it at: https://github.com/ipfs/go-unixfs/blob/master/pb/unixfs.proto.
-
-<!-- TODO: fill in and link to the UnixFS v1 spec or fill in more details about how it works here. -->
+UnixFS is a [protocol-buffers](https://developers.google.com/protocol-buffers/)-based format. You can find the definitions for it [here](https://github.com/ipfs/go-unixfs/blob/master/pb/unixfs.proto).
 
 _Note: we are currently designing an updated version of UnixFS that will be [IPLD](https://ipld.io)-compatible. You can follow along or participate [on GitHub](https://github.com/ipfs/unixfs-v2)._

--- a/docs/essentials/hashing.md
+++ b/docs/essentials/hashing.md
@@ -4,11 +4,7 @@ title: Hashing
 
 # Cryptographic hashing
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
-
-Hashes are functions that take some arbitrary input and return a fixed-length value. The particular value depends on the given hash algorithm in use, such as [SHA-1](https://en.wikipedia.org/wiki/SHA-1) (used by Git), [SHA-256](https://en.wikipedia.org/wiki/SHA-2), or [BLAKE2](<https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2>), but a given hash algorithm always returns the same value for a given input. Have a look at the [full list of hash functions](https://en.wikipedia.org/wiki/List_of_hash_functions) for more.
+Cryptographic hashes are functions that take some arbitrary input and return a fixed-length value. The particular value depends on the given hash algorithm in use, such as [SHA-1](https://en.wikipedia.org/wiki/SHA-1) (used by git), [SHA-256](https://en.wikipedia.org/wiki/SHA-2), or [BLAKE2](<https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2>), but a given hash algorithm always returns the same value for a given input. Have a look at Wikipedia's [full list of hash functions](https://en.wikipedia.org/wiki/List_of_hash_functions) for more.
 
 As an example, the input:
 
@@ -30,15 +26,15 @@ However, the exact same input generates the following output using **SHA-256**:
 
 Notice that the second hash is longer than the first one. This is because SHA-1 creates a 160 bit hash, while SHA-256 creates a 256 bit hash. Also, the prepended `0x` is just an indicator that tells us that the following hash is represented as a base 16 (or hexadecimal) number.
 
-Hashes can be represented in different bases (`base2`, `base16`, `base32`, etc.). In fact, IPFS makes use of that as part of its [Content Identifiers](cid.md) and supports mulitiple base representations at the same time, using the [Multibase](https://github.com/multiformats/multibase) protocol.
+Hashes can be represented in different bases (`base2`, `base16`, `base32`, etc.). In fact, IPFS makes use of that as part of its [content identifiers](/essentials/content-addressing/) and supports mulitiple base representations at the same time, using the [Multibase](https://github.com/multiformats/multibase) protocol.
 
-For example, the SHA-256 hash of "Hello World" from above can be represented as base 32 as:
+For example, the SHA-256 hash of "Hello world" from above can be represented as base 32 as:
 
 ```
 mtwirsqawjuoloq2gvtyug2tc3jbf5htm2zeo4rsknfiv3fdp46a
 ```
 
-## Characteristics of cryptographic hashes
+## Why hashes are important
 
 Cryptographic hashes come with a couple of very important characteristics:
 
@@ -47,6 +43,6 @@ Cryptographic hashes come with a couple of very important characteristics:
 - **unique** - it's infeasible to generate the same hash from two different messages
 - **one-way** - it's infeasible to guess or calculate the input message from its hash
 
-It turns out these features also mean we can use a cryptographic hash to identify any piece of data: the hash is unique to the data we calculated it from and it’s not too long (a hash is a fixed length, so the SHA-256 hash of a 1 Gigabyte video file is still only 32 bytes), so sending it around the network doesn't take up a lot of resources.
+It turns out these features also mean we can use a cryptographic hash to identify any piece of data: the hash is unique to the data we calculated it from and it’s not too long (a hash is a fixed length, so the SHA-256 hash of a one-gigabyte video file is still only 32 bytes), so sending it around the network doesn't take up a lot of resources.
 
-That's critical for a distributed system like IPFS, where we want to be able to store and retrieve data from many places. A computer running IPFS can ask all the peers it's connected to whether they have a file with a particular hash and, if one of them does, they send back the whole file. Without a short, unique identifier like a cryptographic hash, that wouldn't be possible. This technique is called “content addressing” — because the content itself is used to form an address, rather than information about the computer and disk location it's stored at.
+That's critical for a distributed system like IPFS, where we want to be able to store and retrieve data from many places. A computer running IPFS can ask all the peers it's connected to whether they have a file with a particular hash and, if one of them does, they send back the whole file. Without a short, unique identifier like a cryptographic hash, that wouldn't be possible. This technique is called [content addressing](/essentials/content-addressing/) — because the content itself is used to form an address, rather than information about the computer and disk location it's stored at.

--- a/docs/essentials/how-ipfs-works.md
+++ b/docs/essentials/how-ipfs-works.md
@@ -4,17 +4,17 @@ title: How IPFS works
 
 # How IPFS works
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
-
 IPFS is a peer-to-peer (p2p) storage network. Content is accessible through peers that might relay information or store it (or do both), and those peers can be located anywhere in the world. IPFS knows how to find what you ask for by its content address, rather than where it is.
 
-## There are three important things to understand about IPFS
+There are **three key principles** to understanding IPFS:
+
+1. Content addressing and linked data
+2. Turning files into blocks on directed acyclic graphs (DAGs)
+3. Finding and moving content using distributed hash tables (DHTs)
 
 Let’s first look at _content addressing_ and how that content is _linked together_. This “middle” part of the IPFS stack is what connects the ecosystem together; everything is built on being able to find content via linked, unique identifiers.
 
-### 1. Content addressing and linked data
+## Content addressing and linked data
 
 IPFS uses _content addressing_ to identify content by what’s in it, rather than by where it’s located. Looking for an item by content is something you already do all the time. For example, when you look for a book in the library, you often ask for it by the title; that’s content addressing because you’re asking for **what** it is. If you were using location addressing to find that book, you’d ask for it by **where** it is: “I want the book that’s on the second floor, first stack, third shelf from the bottom, four books from the left.” If someone moved that book, you’d be out of luck!
 
@@ -24,9 +24,9 @@ It’s the same on the internet and on your computer. Right now, content is foun
 - `/Users/Alice/Documents/term_paper.doc`
 - `C:\Users\Joe\My Documents\project_sprint_presentation.ppt`
 
-By contrast, every piece of content that uses the IPFS protocol has a [_content identifier_](guides/concepts/cid.md), or CID, that is its _hash_. The hash is unique to the content that it came from, even though it may look short compared to the original content. _If hashes are new to you, check out [the concept guide on hashes](guides/concepts/hashes.md) for an introduction._
+By contrast, every piece of content that uses the IPFS protocol has a [_content identifier_](/essentials/content-addressing/), or CID, that is its _hash_. The hash is unique to the content that it came from, even though it may look short compared to the original content. If hashes are new to you, check out our [guide to cryptographic hashing](/essentials/hashing/) for an introduction.
 
-Content addressing through hashes has become a widely-used means of connecting data in distributed systems, from the commits that back your code to the blockchains that run cryptocurrencies. However, the underlying data structures in these systems are not necessarily interoperable.
+Content addressing through hashes has become a widely-used means of connecting data in distributed systems — everything from the commits that back your code to the blockchains that run cryptocurrencies. However, the underlying data structures in these systems are not necessarily interoperable.
 
 This is where the [IPLD project](https://ipld.io/) comes in. **Hashes identify content, and IPLD translates between data structures**. Since different distributed systems structure their data in different ways, IPLD provides libraries for combining pluggable modules (parsers for each possible type of IPLD node) to resolve a path, selector, or query across many linked nodes (allowing you explore data regardless of the underlying protocol). IPLD provides a way to translate between content-addressable data structures: “Oh you use Git-style, no worries, I can follow those links. Oh you use Ethereum, I got you, I can follow those links too!”
 
@@ -34,23 +34,23 @@ The IPFS protocol uses IPLD to get from raw content to an IPFS address. IPFS has
 
 **Everything else in the IPFS ecosystem builds on top of this core concept: linked, addressable content is the fundamental connecting element that makes the rest work.**
 
-### 2. IPFS turns files into DAGs
+## Directed acyclic graphs (DAGs)
 
-IPFS and many other distributed systems take advantage of a data structure called [directed acyclic graphs](https://en.wikipedia.org/wiki/Directed_acyclic_graph), or DAGs. Specifically, they use _Merkle-DAGs_, which are DAGs where each node has an identifier that is a hash of the node’s contents. Sound familiar? This refers back to the _CID_ concept that we covered in the previous section. Another way to look the this CID-linked-data concept: identifying a data object (like a Merkle-DAG node) by the value of its hash is _content addressing_. _(Check out [the concept guide on Merkle-DAGs](guides/concepts/merkle-DAG.md) for a more in-depth treatment of this topic.)_
+IPFS and many other distributed systems take advantage of a data structure called [directed acyclic graphs](https://en.wikipedia.org/wiki/Directed_acyclic_graph), or DAGs. Specifically, they use _Merkle-DAGs_, which are DAGs where each node has an identifier that is a hash of the node’s contents. Sound familiar? This refers back to the _CID_ concept that we covered in the previous section. Another way to look the this CID-linked-data concept: identifying a data object (like a Merkle-DAG node) by the value of its hash is _content addressing_. Check out our [guide to Merkle-DAGs](/essentials/merkle-dags/) for a more in-depth treatment of this topic.
 
 IPFS uses a Merkle-DAG that is optimized for representing directories and files, but you can structure a Merkle-DAG in many different ways. For example, Git uses a Merkle-DAG that has many versions of your repo inside of it.
 
 To build a Merkle-DAG representation of your content, IPFS often first splits it into _blocks_. Splitting it into blocks means that different parts of the file can come from different sources, and be authenticated quickly. (If you've ever used BitTorrent, you may have noticed that when you download a file, BitTorrent can fetch it from multiple peers at once; this is the same idea.)
 
-Merkle-DAGs are a bit of a [“turtles all the way down”](https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Turtles_all_the_way_down.html) scenario; that is, **everything** has a CID. You’ve got a file that has a CID. What if there are several files in a folder? That folder has a CID, and that CID contains the CIDs of the files underneath. In turn, those files are made up of blocks, and each of those blocks has a CID. You can see how a file system on your computer could be represented as a DAG. You can also see, hopefully, how Merkle-DAG graphs start to form. For a visual exploration of this concept, take a look at our [IPLD Explorer](https://explore.ipld.io/#/explore/QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D).
+Merkle-DAGs are a bit of a [“turtles all the way down”](https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Turtles_all_the_way_down.html) scenario; that is, **everything** has a CID. You’ve got a file that has a CID. What if there are several files in a folder? That folder has a CID, and that CID contains the CIDs of the files underneath. In turn, those files are made up of blocks, and each of those blocks has a CID. You can see how a file system on your computer could be represented as a DAG. You can also see, hopefully, how Merkle-DAG graphs start to form. For a visual exploration of this concept, take a look at the [IPLD Explorer](https://explore.ipld.io/#/explore/QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D).
 
 Another useful feature of Merkle-DAGs and breaking content into blocks is that if you have two similar files, they can share parts of the Merkle-DAG; ie, parts of different Merkle-DAGs can reference the same data. For example, if you update a website, only the files that changed will get new content addresses. Your old version and your new version can refer to the same blocks for everything else. This can make transferring versions of large datasets (such as genomics research or weather data) more efficient because you only need to transfer the parts that are new or have changed instead of creating entirely new files each time.
 
-### 3. The DHT
+## Distributed hash tables (DHTs)
 
 So, to recap, IPFS lets you give CIDs to content, and link that content together in a Merkle-DAG using IPLD. Now let’s move on to the last piece: how you find and move content.
 
-To find which peers are hosting the content you’re after (_discovery_), IPFS uses a [_distributed hash table_](https://en.wikipedia.org/wiki/Distributed_hash_table), or DHT. A hash table is a database of keys to values. A _distributed_ hash table is one where the table is split across all the peers in a distributed network. To find content, you ask these peers.
+To find which peers are hosting the content you’re after (_discovery_), IPFS uses a [distributed hash table](/essentials/dht/), or DHT. A hash table is a database of keys to values. A _distributed_ hash table is one where the table is split across all the peers in a distributed network. To find content, you ask these peers.
 
 The [libp2p project](https://libp2p.io/) is the part of the IPFS ecosystem that provides the DHT and handles peers connecting and talking to each other. (Note that, as with IPLD, libp2p can also be used as a tool for other distributed systems, not just IPFS.)
 
@@ -60,18 +60,14 @@ You’ve discovered your content, and you’ve found the current location(s) of 
 
 There are [other content replication protocols under discussion](https://github.com/ipfs/camp/blob/master/DEEP_DIVES/24-replication-protocol.md) as well, the most developed of which is [_Graphsync_](https://github.com/ipld/specs/blob/master/block-layer/graphsync/graphsync.md). There's also a proposal under discussion to [extend the Bitswap protocol](https://github.com/ipfs/go-bitswap/issues/186) to add functionality around requests and responses.
 
-#### A note on libp2p
+### A note on libp2p
 
 What makes libp2p especially useful for peer to peer connections is _connection multiplexing_. Traditionally, every service in a system would open a different connection to remotely communicate with other services of the same kind. Using IPFS, you open just one connection, and you multiplex everything on that. For everything your peers need to talk to each other about, you send a little bit of each thing, and the other end knows how to sort those chunks where they belong.
 
 This is useful because establishing connections is usually hard to set up and expensive to maintain. With multiplexing, once you have that connection, you can do whatever you need on it.
 
-## And everything is modular
+## A modular paradigm
 
 As you may have noticed from this discussion, the IPFS ecosystem is made up of many modular libraries that support specific parts of any distributed system. You can certainly use any part of the stack independently, or combine them in novel ways.
 
-## Summary
-
 The IPFS ecosystem gives CIDs to content, and links that content together by generating IPLD-Merkle-DAGs. You can discover content using a DHT that's provided by libp2p, and open a connection to any provider of that content and download it using a multiplexed connection. All of this is held together by the “middle” of the stack, which is linked, unique identifiers; that's the essential part that IPFS is built on.
-
-<!--Next, we’ll look at how IPFS is an interconnected network of equal peers, each with the same abilities (no client-server relationships), and what that means for system architectures. We’ll also touch on another useful project in the ecosystem -- IPFS Cluster -- that can help make sure your content is always available, even on a network like IPFS that supports peers dropping in and out at will.-->

--- a/docs/essentials/ipns.md
+++ b/docs/essentials/ipns.md
@@ -4,13 +4,11 @@ title: IPNS
 
 # InterPlanetary Name System (IPNS)
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
+## IPNS in brief
 
-The Inter-Planetary Name System (IPNS) is a system for creating and updating mutable links to IPFS content. Since objects in IPFS are content-addressed, their address changes every time their content does. That’s useful for a variety of things, but it makes it hard to get the latest version of something.
+The InterPlanetary Name System (IPNS) is a system for creating and updating mutable links to IPFS content. Since objects in IPFS are [content addressed](/essentials/content-addressing/), an object's address changes every time an object's content changes. That’s useful for a variety of things, but it makes it hard to get the latest version of something.
 
-A name in IPNS is the hash of a public key. It is associated with a record containing information about the hash it links to that is signed by the corresponding private key. New records can be signed and published at any time.
+A _name_ in IPNS is the [hash](/essentials/hashing) of a public key. It is associated with a record containing information about the hash it links to that is signed by the corresponding private key. New records can be signed and published at any time.
 
 When looking up an IPNS address, use the `/ipns/` prefix:
 
@@ -18,11 +16,9 @@ When looking up an IPNS address, use the `/ipns/` prefix:
 /ipns/QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd
 ```
 
-IPNS is not the only way to create mutable addresses on IPFS. You can also use [DNSLink](/guides/concepts/dnslink) (which is currently much faster than IPNS and also uses more readable names). Other community members are exploring ways to use blockchains to store common name records.
+## An example
 
-**Example:**
-
-Imagine you want to publish your website under IPFS. You can use the [Files API](/guides/concepts/mfs) to publish your static website and then you'll get a CID you can link to. But when you need to make a change, a problem arises: you get a new CID because you now have a different content. And it is not possible for you to be always giving others the new address.
+Imagine you want to publish your website under IPFS. You can use the [Files API](/essentials/file-systems/#mutable-file-system-mfs) to publish your static website, and then you'll get a CID you can link to. But when you need to make a change, a problem arises: you get a new CID because you now have different content. And it is not possible for you to be always giving others the new address.
 
 Here's where the Name API comes in handy. With it, you can create a single, stable IPNS address that points to the CID for the latest version of your website.
 
@@ -39,3 +35,7 @@ ipfs.name.publish(addr, function (err, res) {
 ```
 
 In the same way, you can republish a new version of your website under the same address. By default, `ipfs.name.publish` will use the Peer ID.
+
+## Alternatives to IPNS
+
+IPNS is not the only way to create mutable addresses on IPFS. You can also use [DNSLink](/essentials/dnslink/), which is currently much faster than IPNS and also uses more readable names. Other community members are exploring ways to use blockchains to store common name records.

--- a/docs/essentials/merkle-dags.md
+++ b/docs/essentials/merkle-dags.md
@@ -4,28 +4,24 @@ title: Merkle DAGs
 
 # Merkle Distributed Acyclic Graphs (DAGs)
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
-
 A _Direct Acyclic Graph_ (DAG)is a type of graph in which edges have direction and cycles are not allowed. For example, a linked list like _A→B→C_ is an instance of a DAG where _A_ references _B_ and so on. We say that _B_ is _a child_ or _a descendant of A_, and that _node A has a link to B_. Conversely _A_ is a _parent of B_. We call nodes that are not children to any other node in the DAG _root nodes_.
+
+## Merkle-DAGs in brief
 
 A Merkle-DAG is a DAG where each node has an identifier and this is the result of hashing the node’s contents — any opaque payload carried by the node and the list of identifiers of its children — using a cryptographic hash function like SHA256. This brings some important considerations:
 
-1. Merkle-DAGs can only be constructed from the leaves, that is, from nodes without children. Parents are added after children because the children’s identifiers must be computed in advance to be able to link them.
-1. every node in a Merkle-DAG is the root of a (sub)Merkle-DAG itself, and this subgraph is _contained_ in the parent DAG[9].
-1. Merkle-DAG nodes are _immutable_. Any change in a node would alter its identifier and thus affect all the ascendants in the DAG, essentially creating a different DAG. Take a look at [this helpful illustration using bananas](https://media.consensys.net/ever-wonder-how-merkle-trees-work-c2f8b7100ed3) from our friends at Consensys.
+- Merkle-DAGs can only be constructed from the leaves, that is, from nodes without children. Parents are added after children because the children’s identifiers must be computed in advance to be able to link them.
+- every node in a Merkle-DAG is the root of a (sub)Merkle-DAG itself, and this subgraph is _contained_ in the parent DAG.
+- Merkle-DAG nodes are _immutable_. Any change in a node would alter its identifier and thus affect all the ascendants in the DAG, essentially creating a different DAG. Take a look at [this helpful illustration using bananas](https://media.consensys.net/ever-wonder-how-merkle-trees-work-c2f8b7100ed3) from our friends at Consensys.
 
-Identifying a data object (like a Merkle-DAG node) by the value of its hash is referred to as _content addressing_. Thus, we name the node identifier as _Content Identifier_ or CID.
+Merkle-DAGs are similar to Merkle trees, but there are no balance requirements and every node can carry a payload. In DAGs, several branches can re-converge or, in other words, a node can have several parents.
 
-For example, the previous linked list, assuming that the payload of eachnode is just the CID of its descendant would be: _A=Hash(B)→B=Hash(C)→C=Hash(∅)_. The properties of the hash function ensure thatno cycles can exist when creating Merkle-DAGs[10].
+Identifying a data object (like a Merkle-DAG node) by the value of its hash is referred to as _content addressing_. Thus, we name the node identifier as [_Content Identifier_](/essentials/content-addressing/), or CID.
 
-Merkle-DAGs are _self-verified_ structures. The CID of a node is univocally linked to the contents of its payload and those of all its descendants. Thus two nodes with the same CID univocally represent exactly the same DAG. This will be a key property to efficiently sync Merkle-CRDTs without having to copy the full DAG, as exploited by systems like IPFS. Merkle-DAGs are very widely used. Source control systems like Git [11] and others [6] use them to efficiently store the repository history, in away that enables de-duplicating the objects and detecting conflicts between branches.
+For example, the previous linked list, assuming that the payload of each node is just the CID of its descendant, would be: _A=Hash(B)→B=Hash(C)→C=Hash(∅)_. The properties of the hash function ensure that no cycles can exist when creating Merkle-DAGs. (Note: Hash functions are one-way functions. Creating a cycle should then be impossibly difficult, unless some weakness is discovered and exploited.)
 
-_Excerpted from Markle-CRDT draft paper by @hsanjuan, @haadcode, and @pgte. Available: https://hector.link/presentations/merkle-crdts/merkle-crdts.pdf_
+Merkle-DAGs are _self-verified_ structures. The CID of a node is univocally linked to the contents of its payload and those of all its descendants. Thus two nodes with the same CID univocally represent exactly the same DAG. This will be a key property to efficiently sync Merkle-CRDTs without having to copy the full DAG, as exploited by systems like IPFS. Merkle-DAGs are very widely used. Source control systems like git and others use them to efficiently store the repository history, in away that enables de-duplicating the objects and detecting conflicts between branches.
 
-### Footnotes
+## Further resources
 
-[6] Merkle-DAGs are similar to Merkle Trees [20] but there are no balance requirements and every node can carry a payload. In DAGs, several branches can re-converge or, in other words, a node can have several parents.
-
-[10] Hash functions are one way functions. Creating a cycle should then be impossibly difficult, unless some weakness is discovered and exploited.
+For more information, you may want to read the full [draft Merkle-CRDTs paper](https://hector.link/presentations/merkle-crdts/merkle-crdts.pdf) by [@hsanjuan](https://www.github.com/hsanuan), [@haadcode](https://www.github.com/haadcode), and [@pgte](https://www.github.com/pgte).

--- a/docs/essentials/persistence.md
+++ b/docs/essentials/persistence.md
@@ -4,21 +4,17 @@ title: Persistence
 
 # Persistence, permanence and pinning
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
+IPFS nodes treat the data they store like a cache, meaning that there is no guarantee that the data will continue to be stored. "Pinning" a CID tells an IPFS server that the data is important and mustn't be thrown away.
 
-IPFS nodes treat the data they store like a cache, meaning that there is no guarantee that the data will continue to be stored. Pinning a CID tells an IPFS server that the data is important and mustn't be thrown away.
+You should pin any content you consider important in order to ensure that content is retained over the long term. Since data important to someone else may not be important to you, pinning enables you to have control over the disk space and data retention you need.
 
-You should pin any content you consider important, to ensure that content is retained long-term. Since data important to someone else may not be important to you, pinning lets you have control over the disk space and data retention you need.
-
-## Context
+## Pinning in context
 
 Your IPFS node can store data based on different kinds of user events. For instance, you can add a file with `ipfs add ...`. It will also store data you request, such as by loading a web page through the gateway (`http://localhost:8080/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco`) or with `ipfs cat ...`. Your node will consult with other IPFS peers to find these requested data, and will store the results in the local cache. `ipfs add` will automatically pin the content, but other IPFS commands do not include automatic pinning.
 
 When garbage collection is triggered on a node, any pinned content is automatically exempt from deletion. Non-pinned data may be deleted; if you request it again later, the data can be retrieved from another node.
 
-## Pinning Services
+## Pinning services
 
 To ensure that your important data is retained, you may want to use a pinning service. Such a service normally trades money for the service of guaranteeing they'll keep your data pinned. Some cases where this might be important to you:
 

--- a/docs/essentials/what-is-ipfs.md
+++ b/docs/essentials/what-is-ipfs.md
@@ -4,13 +4,13 @@ title: What is IPFS?
 
 # What is IPFS?
 
-::: warning
-This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
-:::
+Welcome! If you’re new to IPFS — the InterPlanetary File System — you’ve come to the right place. Here is a quick overview of what IPFS is, how it works, and how to use it.
 
-Welcome! If you’re new to IPFS, you’ve come to the right place. Here is a quick overview of what IPFS is, how it works, and how to use it.
+## IPFS, defined
 
-## IPFS is a distributed system for storing and accessing files, websites, applications, and data.
+Let's just start with a one-line definition of IPFS:
+
+**IPFS is a distributed system for storing and accessing files, websites, applications, and data.**
 
 What does that mean, exactly? Let’s say you’re doing some research on aardvarks. (Just roll with it; aardvarks are cool! Did you know they can tunnel 3 feet in only 5 minutes?) You might start by visiting the Wikipedia page on aardvarks at:
 
@@ -26,13 +26,13 @@ However, that's not the only option for meeting your aardvark needs! There's a m
 /ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Aardvark.html
 ```
 
-IPFS knows how to find that sweet, sweet aardvark information by its [contents](/guides/concepts/cid/), not its location (more on that, which is called content-addressing, below). The IPFS-ified version of the aardvark info is represented by that string of numbers in the middle of the URL (`QmXo…`), and instead of asking one of Wikipedia’s computers for the page, your computer uses IPFS to ask lots of computers around the world to share the page with you. It can get your aardvark info from anyone who has it, not just Wikipedia.
+IPFS knows how to find that sweet, sweet aardvark information by its [contents](/essentials/content-addressing/), not its location (more on that, which is called content addressing, below). The IPFS-ified version of the aardvark info is represented by that string of numbers in the middle of the URL (`QmXo…`), and instead of asking one of Wikipedia’s computers for the page, your computer uses IPFS to ask lots of computers around the world to share the page with you. It can get your aardvark info from anyone who has it, not just Wikipedia.
 
 And, when you use IPFS, you don’t just download files from someone else — your computer also helps distribute them. When your friend a few blocks away needs the same Wikipedia page, they might be as likely to get it from you as they would from your neighbor or anyone else using IPFS.
 
 IPFS makes this possible for not only web pages, but also any kind of file a computer might store, whether it’s a document, an email, or even a database record.
 
-## So why does that matter?
+## Why decentralization matters
 
 Making it possible to download a file from many locations that aren’t managed by one organization…
 
@@ -40,9 +40,9 @@ Making it possible to download a file from many locations that aren’t managed 
 - **Makes it harder to censor content.** Because files on IPFS can come from many places, it’s harder for anyone (whether they’re states, corporations, or someone else) to block things. In 2017, Turkey blocked Wikipedia and Spain blocked access to sites related to the Catalonian independence movement. We hope IPFS can help provide ways to circumvent actions like these when they happen.
 - **Can speed up the web when you’re far away or disconnected.** If you can retrieve a file from someone nearby instead of hundreds or thousands of miles away, you can often get it faster. This is especially valuable if your community is networked locally, but doesn’t have a good connection to the wider internet. (Well-funded organizations with technical expertise do this today by using multiple data centers or CDNs — [content distribution networks](https://en.wikipedia.org/wiki/Content_delivery_network). IPFS hopes to make this possible for everyone.)
 
-That last point is actually where IPFS gets its name: **Inter-Planetary File System**. We’re striving to build a system that works across places as disconnected or as far apart as planets. While that's an idealistic goal, it keeps us working and thinking hard, and most everything we create in pursuit of that goal is also useful here at home.
+That last point is actually where IPFS gets its full name: the **InterPlanetary File System**. We’re striving to build a system that works across places as disconnected or as far apart as planets. While that's an idealistic goal, it keeps us working and thinking hard, and most everything we create in pursuit of that goal is also useful here at home.
 
-## Links don’t change on IPFS.
+## Why content addressing matters
 
 What about that link to the aardvark page above? It looked a little unusual:
 
@@ -50,7 +50,7 @@ What about that link to the aardvark page above? It looked a little unusual:
 /ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Aardvark.html
 ```
 
-That jumble of letters after `/ipfs/` is called a [_content identifier_](guides/concepts/cid.md) and it’s how IPFS can get content from multiple places.
+That jumble of letters after `/ipfs/` is called a [_content identifier_](/essentials/content-addressing/) and it’s how IPFS can get content from multiple places.
 
 Traditional URLs and file paths such as…
 
@@ -60,29 +60,25 @@ Traditional URLs and file paths such as…
 
 …identify a file by _where it’s located_ — what computer it’s on and where on that computer’s hard drive it is. That doesn’t work if the file is in many places, though, like your neighbor’s computer and your friend’s across town.
 
-Instead of being location-based, IPFS addresses a file by _what’s in it_, or by its _content_. The content identifier above is a _cryptographic hash_ of the content at that address. The hash is unique to the content that it came from, even though it may look short compared to the original content. It also allows you to verify that you got what you asked for — bad actors can’t just hand you content that doesn’t match. (If hashes are new to you, check out [the concept guide on hashes](guides/concepts/hashes.md) for an introduction.)
+Instead of being location-based, IPFS addresses a file by _what’s in it_, or by its _content_. The content identifier above is a _cryptographic hash_ of the content at that address. The hash is unique to the content that it came from, even though it may look short compared to the original content. It also allows you to verify that you got what you asked for — bad actors can’t just hand you content that doesn’t match. (If hashes are new to you, check out [the concept guide on hashes](/essentials/hashing/) for an introduction.)
 
-<aside class="alert alert-info">
-  Why do we say “content” instead of “files” or “web pages” here? Because a content identifier can point to many different types of data, such as a single small file, a piece of a larger file, or metadata. (In case you don’t know, metadata is “data about the data.” You use metadata when you access the date, location, or file size of your digital pictures, for example.) So, an individual IPFS address can refer to the metadata of just a single piece of a file, a whole file, a directory, a whole website, or any other kind of content. For more on this, check out the <a href="https://docs.ipfs.io/introduction/how-ipfs-works/">How IPFS Works</a> part of these docs.
-</aside>
+::: tip NOTE
+Why do we say “content” instead of “files” or “web pages” here? Because a content identifier can point to many different types of data, such as a single small file, a piece of a larger file, or metadata. (In case you don’t know, metadata is “data about the data.” You use metadata when you access the date, location, or file size of your digital pictures, for example.) So, an individual IPFS address can refer to the metadata of just a single piece of a file, a whole file, a directory, a whole website, or any other kind of content. For more on this, check out our guide to <a href="/essentials/how-ipfs-works/">how IPFS works</a>.
+:::
 
-Because the address of a file in IPFS is created from the content itself, links in IPFS can’t be changed. For example…
+Because the address of a file in IPFS is created from the content itself, links in IPFS can’t be changed. For example ...
 
 - If the text on a web page is changed, the new version gets a new, different address.
 - Content can’t be moved to a different address. On today’s internet, a company could reorganize content on their website and move a page at `http://mycompany.com/what_we_do` to `http://mycompany.com/services`. In IPFS, the old link you have would still point to the same old content.
 
-Of course, people want to update and change content all the time, and don’t want to send new links every time they do it. This is entirely possible in an IPFS world, but explaining it requires a little more info than what’s within the scope of this IPFS introduction. Check out the concept guides on [IPNS](guides/concepts/ipns.md"), the [Mutable File System (MFS)](guides/concepts/mfs.md"), and [DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/) to learn more about how changing content can work in a content-addressed, distributed system.
+Of course, people want to update and change content all the time, and don’t want to send new links every time they do it. This is entirely possible in an IPFS world, but explaining it requires a little more info than what’s within the scope of this IPFS introduction. Check out the concept guides on [IPNS](/essentials/ipns/), the [Mutable File System (MFS)](/essentials/file-systems/#mutable-file-system-mfs), and [DNSLink](/essentials/dnslink/) to learn more about how changing content can work in a content-addressed, distributed system.
 
 It’s important to remember in all of these situations, using IPFS is participatory and collaborative. If nobody using IPFS has the content identified by a given address available for others to access, you won’t be able to get it. On the other hand, content can’t be removed from IPFS as long as _someone_ is interested enough to make it available, whether that person is the original author or not. Note that this is similar to the current web, where it is also impossible to remove content that's been copied across an unknowable number websites; the difference with IPFS is that you are always able to find those copies.
 
-## It’s all about possession and participation.
+## Why participation matters
 
 While there’s lots of complex technology in IPFS, the fundamental ideas are about changing how networks of people and computers communicate. Today’s World Wide Web is structured on _ownership_ and _access_, meaning that you get files from whoever owns them — if they choose to grant you access. IPFS is based on the ideas of _possession_ and _participation_, where many people _possess_ each others’ files and _participate_ in making them available.
 
-That means IPFS only works well when people are actively participating. If you use your computer to share files using IPFS, but then you turn your computer off, other people won’t be able to get those files from you anymore. But if you or others make sure that copies of those files are stored on more than one computer that’s powered on and running IPFS, those files will be more reliably available to other IPFS users who want them. This happens to some extent automatically: by default, your computer shares a file with others for a limited time after you’ve downloaded it using IPFS. You can also make content available more permanently by _pinning_ it, which saves it to your computer and makes it available on the IPFS network until you decide to _unpin_ it. (You can learn more about this in the [concept guide on pinning](guides/concepts/pinning.md).)
+That means IPFS only works well when people are actively participating. If you use your computer to share files using IPFS, but then you turn your computer off, other people won’t be able to get those files from you anymore. But if you or others make sure that copies of those files are stored on more than one computer that’s powered on and running IPFS, those files will be more reliably available to other IPFS users who want them. This happens to some extent automatically: by default, your computer shares a file with others for a limited time after you’ve downloaded it using IPFS. You can also make content available more permanently by _pinning_ it, which saves it to your computer and makes it available on the IPFS network until you decide to _unpin_ it. (You can learn more about this in our [guide to persistence and pinning](/essentials/persistence).)
 
 If you want to make sure one of your own files is permanently shared on the internet today, you might use a for-pay file-sharing service like Dropbox. Some people have begun offering similar services based on IPFS called _pinning services_. But since IPFS makes this kind of sharing a built-in feature, you can also collaborate with friends or partner with institutions (for example, museums and libraries might work together) to share each others’ files. We hope IPFS can be the low-level tool that allows a rich fabric of communities, business, and cooperative organizations to all form a distributed web that is much more reliable, robust, and equitable than the one we have today.
-
-## Next Steps
-
-Sound interesting? You can continue to our more in-depth explanation of [how the IPFS ecosystem works](introduction/how-ipfs-works.md). To dive right in and install IPFS, visit our [getting started guide](introduction/usage.md").

--- a/docs/how-tos/command-line-quick-start.md
+++ b/docs/how-tos/command-line-quick-start.md
@@ -1,0 +1,187 @@
+---
+title: Command-line quick start
+---
+
+# Command-line quick start
+
+::: warning
+This draft content ported from the legacy docs site may contain broken links and other errors. (Please remove this alert once content has been reviewed.)
+:::
+
+## Install IPFS
+
+If you haven’t done so already, your first step is to **install IPFS**! Most people prefer to install a prebuilt package, which you can do on the [IPFS distributions page](https://dist.ipfs.io/#go-ipfs) by clicking “Install go-ipfs” (our reference implementation written in Go) and then following the instructions for [installing from a prebuilt package](../install/#installing-from-a-prebuilt-package).
+
+<a class="button button-primary" href="https://dist.ipfs.io/#go-ipfs" role="button">
+  Download IPFS for your platform &nbsp;&nbsp;<i class="fa fa-download" aria-hidden="true"></i>
+</a>
+
+<aside class="alert alert-info">
+  Don’t want to use the command line right now? You can give the desktop-app implementation of IPFS a go! <a href="https://github.com/ipfs-shipyard/ipfs-desktop">Get started with IPFS Desktop here <i class="fas fa-external-link-square-alt fa-sm"></i></a>
+</aside>
+
+For more install options, such as building from source, and toubleshooting tips, visit our [install guide]{guides/guides/install.md). If you have any questions or get stuck, feel free to ask for help in [the Help section of the IPFS forums](https://discuss.ipfs.io/c/help) or in [#ipfs on chat.freenode.net](irc://chat.freenode.net/%23ipfs).
+
+## Initialize the repository
+
+`ipfs` stores all its settings and internal data in a directory called the _repository._ Before using IPFS for the first time, you’ll need to initialize the repository with the `ipfs init` command:
+
+```sh
+> ipfs init
+initializing ipfs node at /Users/jbenet/.go-ipfs
+generating 2048-bit RSA keypair...done
+peer identity: Qmcpo2iLBikrdf1d6QU6vXuNb6P7hwrbNPW9kLAH8eG67z
+to get started, enter:
+
+  ipfs cat /ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/readme
+
+```
+
+<div class="alert alert-warning">
+    <p>
+        If you are running on a server in a data center, you should initialize IPFS with the <code>server</code> profile. This will prevent IPFS from creating a lot of data center-internal traffic trying to discover local nodes:
+    </p>
+
+    <pre><code class="language-sh">&gt; ipfs init --profile server</code></pre>
+
+    <p>
+        There are a whole host of other configuration options you may want to set — check <a href="https://github.com/ipfs/go-ipfs/blob/v0.4.15/docs/config.md">the full reference</a> for more.
+    </p>
+
+</div>
+
+<div class="alert alert-info">
+    The hash after <code>peer identity: </code> is your node’s ID and will be different from the one shown in the above output. Other nodes on the network use it to find and connect to you. You can run <code>ipfs id</code> at any time to get it again if you need it.
+</div>
+
+Now, try running the command suggested to you in the output of `ipfs init`. The one that looks like `ipfs cat /ipfs/<HASH>/readme`.
+
+You should see something like this:
+
+```
+Hello and Welcome to IPFS!
+
+██╗██████╗ ███████╗███████╗
+██║██╔══██╗██╔════╝██╔════╝
+██║██████╔╝█████╗  ███████╗
+██║██╔═══╝ ██╔══╝  ╚════██║
+██║██║     ██║     ███████║
+╚═╝╚═╝     ╚═╝     ╚══════╝
+
+If you're seeing this, you have successfully installed
+IPFS and are now interfacing with the ipfs merkledag!
+
+ -------------------------------------------------------
+| Warning:                                              |
+|   This is alpha software. use at your own discretion! |
+|   Much is missing or lacking polish. There are bugs.  |
+|   Not yet secure. Read the security notes for more.   |
+ -------------------------------------------------------
+
+Check out some of the other files in this directory:
+
+  ./about
+  ./help
+  ./quick-start     <-- usage examples
+  ./readme          <-- this file
+  ./security-notes
+
+```
+
+You can explore other objects in the repository. In particular, the `quick-start` directory which shows example commands to try:
+
+```sh
+ipfs cat /ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/quick-start
+```
+
+## Taking your Node Online
+
+Once you're ready to join your node to the public network, run the ipfs daemon in another terminal and wait for all three lines below to appear to know that your node is ready:
+
+```sh
+> ipfs daemon
+Initializing daemon...
+API server listening on /ip4/127.0.0.1/tcp/5001
+Gateway server listening on /ip4/127.0.0.1/tcp/8080
+```
+
+<div class="alert alert-info">
+Make note of the tcp ports you receive. If they are different, use yours in the commands below.
+</div>
+
+Now, switch back to your original terminal. If you’re connected to the network,
+you should be able to see the ipfs addresses of your peers when you run:
+
+```sh
+> ipfs swarm peers
+/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
+/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx
+/ip4/134.121.64.93/tcp/1035/ipfs/QmWHyrPWQnsz1wxHR219ooJDYTvxJPyZuDUPSDpdsAovN5
+/ip4/178.62.8.190/tcp/4002/ipfs/QmdXzZ25cyzSF99csCQmmPZ1NTbWTe8qtKFaZKpZQPdTFB
+```
+
+These are a combination of `<transport address>/ipfs/<hash-of-public-key>`.
+
+Now, you should be able to get objects from the network. Try:
+
+```sh
+ipfs cat /ipfs/QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ/cat.jpg >cat.jpg
+open cat.jpg
+```
+
+Next try sending objects to the network, and then
+viewing it in your favorite browser. The example below uses `curl`
+as the browser, but you can open the IPFS URL in other browsers as well:
+
+```sh
+> hash=`echo "I <3 IPFS -$(whoami)" | ipfs add -q`
+> curl "https://ipfs.io/ipfs/$hash"
+I <3 IPFS -<your username>
+```
+
+Cool, huh? The gateway served a file _from your computer_. The gateway queried
+the Distributed hash table (DHT), found your machine, requested the file, your machine sent it to the
+gateway, and the gateway sent it to your browser.
+
+<div class="alert alert-warning">
+    Depending on the state of the network, <code>curl</code> may take a while. The public gateways may be overloaded or having a hard time reaching you.
+</div>
+
+You can also check it out at your own local gateway:
+
+```sh
+> curl "http://127.0.0.1:8080/ipfs/$hash"
+I <3 IPFS -<your username>
+```
+
+By default, your gateway is not exposed to the world, it only works locally.
+
+## Web Console
+
+We also have a web console you can use to check the state of your node.
+In your favorite web browser, open:
+
+<pre><code><a href="http://localhost:5001/webui">http://localhost:5001/webui</a></code></pre>
+
+This should bring up a console like this:
+
+![Web console connection view](https://docs.ipfs.io/introduction/assets/webui-connection.png)
+
+## Companion Browser Extension
+
+While we are at it, [IPFS Companion](https://github.com/ipfs-shipyard/ipfs-companion#ipfs-companion) is a
+browser extension that simplifies access to IPFS resources and adds support for
+the IPFS protocol.
+
+<div class="alert alert-info">
+It will automatically redirect IPFS gateway requests to
+your local daemon so that you are not relying on, or trusting, remote gateways.
+</div>
+
+It runs in Firefox (Desktop and Android)
+and various Chromium-based browsers such as Google Chrome or Brave.
+Check [its features](https://github.com/ipfs-shipyard/ipfs-companion#features) and [**install it**](https://github.com/ipfs-shipyard/ipfs-companion#install) today!
+
+| [Firefox](https://www.mozilla.org/firefox/new/) / [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox)                       | [Chrome](https://www.google.com/chrome/) / [Brave](https://brave.com/)                                                                                                                   |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [![Install From Firefox Add-ons](https://docs.ipfs.io/introduction/assets/get-the-firefox-add-on.png)](https://addons.mozilla.org/firefox/addon/ipfs-companion/) | [![Install from Chrome Store](https://docs.ipfs.io/introduction/assets/chrome-web-store.png)](https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch) |

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -26,3 +26,180 @@ Want to run IPFS for/with others? Install Cluster
 ## Integrate IPFS into your app: go-ipfs & js-ipfs
 
 Want to integrate IPFS in your app? Install go & js, with comparison
+
+## Original legacy docs install guide — these items will need to be incorporated somewhere
+
+There are a variety of ways to install a copy of IPFS on your system. We generally recommend [installing a prebuilt package](#installing-from-a-prebuilt-package), but here are a few other supported options:
+
+- [Installing from a Prebuilt Package](#installing-from-a-prebuilt-package) (recommended)
+- [Installing with ipfs-update](#installing-with-ipfs-update)
+- [Building from source](#building-from-source)
+- [Upgrading IPFS](#upgrading-ipfs)
+- [Troubleshooting](#troubleshooting)
+
+Note these instructions all make use of the **command line.** We use `$` to indicate the command prompt — commands to type are on lines that are prefixed with that, while output lines are un-prefixed.
+
+---
+
+## Installing from a Prebuilt Package
+
+First, download the right version of IPFS for your platform:
+
+<a class="button button-primary" href="https://dist.ipfs.io/#go-ipfs" role="button">
+  Download IPFS for your platform &nbsp;&nbsp;<i class="fa fa-download" aria-hidden="true"></i>
+</a>
+
+### macOS and Linux
+
+After downloading, untar the archive, and move the `ipfs` binary somewhere in your executables `$PATH` using the `install.sh` script:
+
+```sh
+$ tar xvfz go-ipfs.tar.gz
+$ cd go-ipfs
+$ ./install.sh
+```
+
+Test it out:
+
+```sh
+$ ipfs help
+USAGE:
+
+    ipfs - Global p2p merkle-dag filesystem.
+...
+```
+
+Congratulations! You now have a working IPFS installation on your computer.
+
+### Windows
+
+After downloading, unzip the archive, and move `ipfs.exe` somewhere in your `%PATH%`.
+
+Test it out:
+
+```sh
+$ ipfs help
+USAGE:
+
+    ipfs - Global p2p merkle-dag filesystem.
+...
+```
+
+Congratulations! You now have a working IPFS installation on your computer.
+
+---
+
+## Installing with ipfs-update
+
+`ipfs-update` is a command-line tool to install and upgrade the `ipfs` binary.
+
+### Getting ipfs-update
+
+`ipfs-update` can be downloaded for your platform at: https://dist.ipfs.io/#ipfs-update
+
+If you have a working Go environment (>=1.12), you can also install it with:
+
+```
+$ go get -u github.com/ipfs/ipfs-update
+```
+
+When installing new versions of `ipfs` or upgrading make sure you are using the latest version of `ipfs-update`.
+
+### Installing ipfs with ipfs-update
+
+`ipfs-update versions` lists all the available `ipfs` versions which are available for download:
+
+```
+$ ipfs-update versions
+v0.3.2
+[...]
+v0.4.20
+v0.4.21
+```
+
+`ipfs-update install latest` will install the latest available version:
+
+```
+$ ipfs-update install latest
+fetching go-ipfs version v0.4.21
+binary downloaded, verifying...
+success!
+stashing old binary
+installing new binary to /home/hector/go/bin/ipfs
+checking if repo migration is needed...
+Installation complete!
+```
+
+Note that the latest available version may not be stable (i.e. release candidates
+in the form `vX.X.X-rcX`). So it is recommended to specify the version you want
+to install, for example: `ipfs-update install v0.4.21`.
+
+---
+
+## Building from Source
+
+If you want, you can also build IPFS from source.
+If you are on macOS or Linux, take a look at [the readme](https://github.com/ipfs/go-ipfs#build-from-source) for install instructions.
+If you are on Windows, take a look at [this document](https://github.com/ipfs/go-ipfs/blob/master/docs/windows.md) for instructions.
+
+---
+
+## Upgrading IPFS
+
+`ipfs` upgrades (and downgrades) may involve a repository upgrade process performed by the
+[fs-repo-migrations](https://dist.ipfs.io/#fs-repo-migrations) tool.
+
+### Upgrading using ipfs-update
+
+`ipfs-update install` will download and run `fs-repo-migrations` when needed, during the installation of
+a newer or older `ipfs` version (as explained above). This is the easiest way of upgrading.
+
+<div class="message mb">
+  <strong>Warning:</strong> Make sure that the ipfs daemon is not running during an upgrade
+</div>
+
+### Upgrading manually
+
+In order to perform a manual upgrade of `ipfs`, you will need to manually run any repository migrations. The
+procedure is as follows:
+
+- Stop the `ipfs` daemon if it is running
+- Optionally backup your `ipfs` data folder (i.e. `cp -aL ~/.ipfs ~/.ipfs.bk`)
+- Download and install the latest version of `ipfs` from [https://dist.ipfs.io/#go-ipfs](https://dist.ipfs.io/#go-ipfs)
+- Run `ipfs daemon`.
+
+When a repository migration is necessary, `ipfs` will inform the user, download and install `fs-repo-migrations`
+and perform the upgrade. If you wish the procedure to happen unattended, launch the daemon with the `--migrate`
+flag.
+
+Migrations can be also run manually by downloading the latest version of `fs-repo-migrations`
+from [https://dist.ipfs.io/#fs-repo-migrations](https://dist.ipfs.io/#fs-repo-migrations) and
+[following these instructions](https://github.com/ipfs/fs-repo-migrations/blob/master/run.md).
+
+---
+
+## Troubleshooting
+
+### Help!
+
+If you have any problems, come get live help at
+[#ipfs](/#community) or via [the mailing list](/#community).
+
+### Check Go Version
+
+IPFS works with Go 1.12.0 or later.
+To check what go version you have installed, type `go version`.
+Here's what I get:
+
+```sh
+$ go version
+go version go1.12.2 linux/amd64
+```
+
+If you need to update, it is recommended to install from the
+[canonical Go packages](https://golang.org/doc/install).
+Package managers often contain out-of-date Go packages.
+
+### Install FUSE
+
+For more details on setting up FUSE (so that you can mount the filesystem), see [github.com/ipfs/go-ipfs/blob/master/docs/fuse.md](https://github.com/ipfs/go-ipfs/blob/master/docs/fuse.md)


### PR DESCRIPTION
Resolved links and other problems in markdown files in the Essentials section of the site.
Remaining sections:
- Install IPFS
- How-tos
- API & CLI
- Support & community
- Project