### PR TITLE
Feat add corecourses

### DIFF
--- a/docs/essentials/README.md
+++ b/docs/essentials/README.md
@@ -6,6 +6,14 @@ title: Essentials
 
 New to IPFS or the distributed web? Here's where to get started on understanding the key ingredients in what makes IPFS work. Because IPFS is a system that hopes to change how we use the Internet, it comes with many new concepts! This section aims to get you up to speed quickly.
 
+## Video overviews
+
+Want the basics, in theater mode? Check out these Core Courses from IPFS Camp 2019 for an overview of how IPFS works with files and the overall data lifecycle in dweb.
+
+@[youtube](fLUq0RkiTBA)
+
+@[youtube](Z5zNPwMDYGg)
+
 ## IPFS in a nutshell
 
 Get the basic concepts of IPFS in one place, including:

--- a/docs/essentials/bitswap.md
+++ b/docs/essentials/bitswap.md
@@ -6,3 +6,5 @@ sidebarDepth: 0
 # Bitswap
 
 ## This content is still preparing for liftoff.
+
+In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=fLUq0RkiTBA) on how Bitswap fits into the overall lifecycle of data in IPFS!

--- a/docs/essentials/content-addressing.md
+++ b/docs/essentials/content-addressing.md
@@ -4,6 +4,10 @@ title: Content addressing
 
 # Content addressing and CIDs
 
+::: tip
+If you're interested in how content addressing fits into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
+:::
+
 A _content identifier_, or CID, is a label used to point to material in IPFS. It doesn't indicate _where_ the content is stored, but it forms a kind of address based on the content itself. CIDs are short, regardless of the size of their underlying content.
 
 CIDs are based on the content’s [cryptographic hash](/essentials/hashing/). That means:

--- a/docs/essentials/dht.md
+++ b/docs/essentials/dht.md
@@ -4,6 +4,10 @@ title: Distributed Hash Tables (DHTs)
 
 # Distributed Hash Tables (DHTs)
 
+::: tip
+If you're interested in how DHTs fit into the overall lifecycle of data in IPFS, check out this video from IPFS Camp 2019! [Core Course: The Lifecycle of Data in Dweb](https://www.youtube.com/watch?v=fLUq0RkiTBA)
+:::
+
 ## What is a DHT?
 
 [Distributed Hash Tables](https://en.wikipedia.org/wiki/Distributed_hash_table) (DHTs) are distributed key-value stores where keys are [cryptographic hashes](/essentials/hashing).

--- a/docs/essentials/file-systems.md
+++ b/docs/essentials/file-systems.md
@@ -11,6 +11,10 @@ Working with files in IPFS can be a little different than you're used to for sev
 
 MFS and UnixFS can help you address these new ways of thinking of files.
 
+::: tip
+If you're interested in how MFS and UnixFS play into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
+:::
+
 ## Mutable File System (MFS)
 
 Because files in IPFS are content-addressed and immutable, they can be complicated to edit. Mutable File System (MFS) is a tool built into IPFS that lets you treat files like you would a normal name-based filesystem — you can add, remove, move, and edit MFS files and have all the work of updating links and hashes taken care of for you.

--- a/docs/essentials/hashing.md
+++ b/docs/essentials/hashing.md
@@ -4,6 +4,10 @@ title: Hashing
 
 # Cryptographic hashing
 
+::: tip
+If you're interested in how cryptographic hashes fit into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
+:::
+
 Cryptographic hashes are functions that take some arbitrary input and return a fixed-length value. The particular value depends on the given hash algorithm in use, such as [SHA-1](https://en.wikipedia.org/wiki/SHA-1) (used by git), [SHA-256](https://en.wikipedia.org/wiki/SHA-2), or [BLAKE2](<https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2>), but a given hash algorithm always returns the same value for a given input. Have a look at Wikipedia's [full list of hash functions](https://en.wikipedia.org/wiki/List_of_hash_functions) for more.
 
 As an example, the input:

--- a/docs/essentials/how-ipfs-works.md
+++ b/docs/essentials/how-ipfs-works.md
@@ -4,6 +4,10 @@ title: How IPFS works
 
 # How IPFS works
 
+::: tip
+Want to see a video recap of how IPFS works with files in general? Check out this content from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
+:::
+
 IPFS is a peer-to-peer (p2p) storage network. Content is accessible through peers that might relay information or store it (or do both), and those peers can be located anywhere in the world. IPFS knows how to find what you ask for by its content address, rather than where it is.
 
 There are **three key principles** to understanding IPFS:

--- a/docs/essentials/immutability.md
+++ b/docs/essentials/immutability.md
@@ -6,3 +6,5 @@ sidebarDepth: 0
 # Immutability
 
 ## This content is still preparing for liftoff.
+
+In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=Z5zNPwMDYGg) on why immutability is important to how IPFS deals with files.

--- a/docs/essentials/merkle-dag.md
+++ b/docs/essentials/merkle-dag.md
@@ -4,6 +4,10 @@ title: Merkle DAGs
 
 # Merkle Distributed Acyclic Graphs (DAGs)
 
+::: tip
+If you're interested in how Merkle DAGs fit into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
+:::
+
 A _Direct Acyclic Graph_ (DAG) is a type of graph in which edges have direction and cycles are not allowed. For example, a linked list like _A→B→C_ is an instance of a DAG where _A_ references _B_ and so on. We say that _B_ is _a child_ or _a descendant of A_, and that _node A has a link to B_. Conversely _A_ is a _parent of B_. We call nodes that are not children to any other node in the DAG _root nodes_.
 
 ## Merkle DAGs in brief

--- a/docs/essentials/persistence.md
+++ b/docs/essentials/persistence.md
@@ -4,6 +4,10 @@ title: Persistence
 
 # Persistence, permanence and pinning
 
+::: tip
+If you're interested in how pinning files fits into the overall lifecycle of data in IPFS, check out this video from IPFS Camp 2019! [Core Course: The Lifecycle of Data in Dweb](https://www.youtube.com/watch?v=fLUq0RkiTBA)
+:::
+
 IPFS nodes treat the data they store like a cache, meaning that there is no guarantee that the data will continue to be stored. "Pinning" a CID tells an IPFS server that the data is important and mustn't be thrown away.
 
 You should pin any content you consider important in order to ensure that content is retained over the long term. Since data important to someone else may not be important to you, pinning enables you to have control over the disk space and data retention you need.


### PR DESCRIPTION
Incorporated the four core courses from IPFS Camp:
- Courses A and D are broad enough to touch multiple "essentials" topics, so added tip callouts to them in their respective topic pages, plus prompts in the top-level essentials page
- Courses B and C added to nav in the "How-tos" section

Ref https://github.com/ipfs/docs/issues/187