### PR TITLE
Modify h2, h3, h4 headers for search.

### DIFF
--- a/docs/essentials/bitswap.md
+++ b/docs/essentials/bitswap.md
@@ -5,6 +5,4 @@ sidebarDepth: 0
 
 # Bitswap
 
-## This content is still preparing for liftoff.
-
-In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=fLUq0RkiTBA) on how Bitswap fits into the overall lifecycle of data in IPFS!
+> This content is still preparing for liftoff. In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=fLUq0RkiTBA) on how Bitswap fits into the overall lifecycle of data in IPFS!

--- a/docs/essentials/content-addressing.md
+++ b/docs/essentials/content-addressing.md
@@ -15,7 +15,7 @@ CIDs are based on the content’s [cryptographic hash](/essentials/hashing/). Th
 - Any difference in content will produce a different CID and
 - The same piece of content added to two different IPFS nodes using the same settings will produce _exactly the same CID_.
 
-## Identifier Formats
+## Identifier formats
 
 CIDs can take a few different forms with different encoding bases or CID versions. Many of the existing IPFS tools still generate v0 CIDs, although the `files` ([Mutable File System](/essentials/file-systems/#mutable-file-system-mfs)) and `object` operations now use CIDv1 by default.
 

--- a/docs/essentials/content-addressing.md
+++ b/docs/essentials/content-addressing.md
@@ -2,7 +2,7 @@
 title: Content addressing
 ---
 
-# Content addressing and CIDs
+# Content Addressing and CIDs
 
 ::: tip
 If you're interested in how content addressing fits into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
@@ -15,17 +15,17 @@ CIDs are based on the content’s [cryptographic hash](/essentials/hashing/). Th
 - Any difference in content will produce a different CID and
 - The same piece of content added to two different IPFS nodes using the same settings will produce _exactly the same CID_.
 
-## CID formats
+## Identifier Formats
 
 CIDs can take a few different forms with different encoding bases or CID versions. Many of the existing IPFS tools still generate v0 CIDs, although the `files` ([Mutable File System](/essentials/file-systems/#mutable-file-system-mfs)) and `object` operations now use CIDv1 by default.
 
-### Version 0
+### Version 0 (v0)
 
 When IPFS was first designed, we used base 58-encoded multihashes as the content identifiers (This is simpler, but much less flexible than newer CIDs). CIDv0 is still used by default for many IPFS operations, so you should generally try to support v0.
 
 If a CID is 46 characters starting with "Qm", it's a CIDv0 (for more details, check the [decoding algorithm](https://github.com/ipld/cid/blob/ef1b2002394b15b1e6c26c30545fd485f2c4c138/README.md#decoding-algorithm) in the CID specification).
 
-### Version 1
+### Version 1 (v1)
 
 CID v1 contains some leading identifiers that clarify exactly which representation is used, along with the content-hash itself. These include:
 

--- a/docs/essentials/content-addressing.md
+++ b/docs/essentials/content-addressing.md
@@ -2,7 +2,7 @@
 title: Content addressing
 ---
 
-# Content Addressing and CIDs
+# Content addressing and CIDs
 
 ::: tip
 If you're interested in how content addressing fits into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)

--- a/docs/essentials/dht.md
+++ b/docs/essentials/dht.md
@@ -57,7 +57,7 @@ The higher m is, the harder it is to find peers that have the same ID up to m bi
 "Close" here is defined as the XOR distance, so the longer the prefix they share, the closer they are.
 Lists also have a maximum of entries (k) — otherwise the first lists would contain half the network, then a fourth of the network, and so on.
 
-## How to Use DHTs
+## How to use DHTs
 
 When a peer receives a lookup request, it will either answer with a value if it falls into its own bucket, or answer with the contacting information (IP+port, `peerID`, etc.) of a closer peer. The requesting peer can then send its request to this closer peer. The process goes on until a peer is able to answer it.
 A request for a hash of length n will take at maximum log2(n) steps, or even log2m(n).

--- a/docs/essentials/dht.md
+++ b/docs/essentials/dht.md
@@ -8,8 +8,6 @@ title: Distributed Hash Tables (DHTs)
 If you're interested in how DHTs fit into the overall lifecycle of data in IPFS, check out this video from IPFS Camp 2019! [Core Course: The Lifecycle of Data in Dweb](https://www.youtube.com/watch?v=fLUq0RkiTBA)
 :::
 
-## What is a DHT?
-
 [Distributed Hash Tables](https://en.wikipedia.org/wiki/Distributed_hash_table) (DHTs) are distributed key-value stores where keys are [cryptographic hashes](/essentials/hashing).
 
 DHTs are, by definition, distributed. Each "peer" (or "node") is responsible for a subset of the DHT.
@@ -26,15 +24,11 @@ DHTs' decentralization provides advantages compared to a traditional key-value s
 - _fault tolerance_ via redundancy, so that lookups are possible even if peers unexpectedly leave or join the DHT. Additionally, requests can be addressed to any peer if another peer is slow or unavailable.
 - _load balancing_, since requests are made to different nodes and no unique peers process all the requests.
 
-## DHTs on IPFS
-
-Now that we know what DHTs are, let's take a look specifically at how DHTs work on IPFS.
-
-### Peer IDs
+## Peer IDs
 
 Each peer has a `peerID`, which is a hash with the same length _n_ as the DHT keys.
 
-### Buckets
+## Buckets
 
 A subset of the DHT maintained by a peer is called a 'bucket'.
 A bucket maps to hashes with the same prefix as the `peerID`, up to _m_ bits. There are 2^m buckets. Each bucket maps for 2^(n-m) hashes.
@@ -47,7 +41,7 @@ Several peers can be in charge of the same bucket if they have the same prefix.
 
 In most DHTs, including [IPFS's Kademlia implementation](https://github.com/libp2p/specs/blob/8b89dc2521b48bf6edab7c93e8129156a7f5f02c/kad-dht/README.md), the size of the buckets (and the size of the prefix), are dynamic.
 
-### Peer lists
+## Peer lists
 
 Peers also keep a connection to other peers in order to forward requests if the requested hash is not in their own bucket.
 
@@ -63,15 +57,14 @@ The higher m is, the harder it is to find peers that have the same ID up to m bi
 "Close" here is defined as the XOR distance, so the longer the prefix they share, the closer they are.
 Lists also have a maximum of entries (k) — otherwise the first lists would contain half the network, then a fourth of the network, and so on.
 
-### Using the DHT
+## How to Use DHTs
 
 When a peer receives a lookup request, it will either answer with a value if it falls into its own bucket, or answer with the contacting information (IP+port, `peerID`, etc.) of a closer peer. The requesting peer can then send its request to this closer peer. The process goes on until a peer is able to answer it.
 A request for a hash of length n will take at maximum log2(n) steps, or even log2m(n).
 
-### Keys and hashes
+### Keys and Hashes
 
-In IPFS's Kademlia DHT, keys are SHA256 hashes.
-[PeerIDs](https://docs.libp2p.io/concepts/peer-id/) are those of [libp2p](https://libp2p.io/), the networking library used by IPFS.
+In IPFS's Kademlia DHT, keys are SHA256 hashes. [PeerIDs](https://docs.libp2p.io/concepts/peer-id/) are those of [libp2p](https://libp2p.io/), the networking library used by IPFS.
 
 We use the DHT to look up two types of objects, both represented by SHA256 hashes:
 
@@ -82,9 +75,7 @@ Consequently, IPFS's DHT is one of the ways to achieve mutable and immutable [co
 
 You can learn more in the [libp2p Kademlia DHT specification](https://github.com/libp2p/specs/blob/8b89dc2521b48bf6edab7c93e8129156a7f5f02c/kad-dht/README.md).
 
-## Usage
-
-### Adding an entry
+### Add an Entry
 
 Adding a blob of data to IPFS is the equivalent of advertising that you have it. Since DHT is the only content routing implemented, you can just use:
 `ipfs add myData`

--- a/docs/essentials/dnslink.md
+++ b/docs/essentials/dnslink.md
@@ -4,8 +4,6 @@ title: DNSLink
 
 # DNSLink
 
-## What is DNSLink?
-
 DNSLink uses [DNS TXT](https://en.wikipedia.org/wiki/TXT_record) records to map a domain name (like `ipfs.io`) to an IPFS address. Because you can edit your DNS records, you can use them to always point to the latest version of an object in IPFS (remember that an IPFS object’s address changes if you modify the object). Since DNSLink uses DNS records, you can assign names/paths/(sub)domains/whatever that are easy to type, read, and remember.
 
 A DNSLink address looks like an [IPNS](/guides/concepts/ipns) address, but it uses a domain name in place of a hashed public key:
@@ -20,7 +18,7 @@ Just like normal IPFS addresses, they can include links to other files — or ot
 /ipns/myexampledomain.org/media/
 ```
 
-### Publishing using a subdomain
+## Publish Using a Subdomain
 
 While you can publish the TXT record to the exact domain if you so wish, it can be more advantageous to publish DNSLink records using a special subdomain called `_dnslink`. This enables you to improve the security of an automated setup, or delegate control over your DNSLink records to a third party without giving away full control over the original DNS zone.
 
@@ -32,7 +30,7 @@ $ dig +noall +answer TXT _dnslink.docs.ipfs.io
 _dnslink.docs.ipfs.io.  34  IN  TXT "dnslink=/ipfs/QmVMxjouRQCA2QykL5Rc77DvjfaX6m8NL6RyHXRTaZ9iya"
 ```
 
-### Resolving using DNSLink
+## Resolve Using DNSLink
 
 When an IPFS client or node attempts to resolve an address, it looks for a `TXT` record that is prefixed with `dnslink=`. The rest can be an `/ipfs/` link (as in the example below), or `/ipns/`, or even a link to another DNSLink.
 
@@ -59,6 +57,6 @@ Will get you this block:
 /ipfs/QmVMxjouRQCA2QykL5Rc77DvjfaX6m8NL6RyHXRTaZ9iya/introduction/
 ```
 
-## Further resources
+## Further Resources
 
 For a complete guide to DNSLink — including tutorials, usage examples and FAQs — check out [dnslink.io](http://dnslink.io/).

--- a/docs/essentials/file-systems.md
+++ b/docs/essentials/file-systems.md
@@ -27,7 +27,7 @@ This video also provides a good overview of MFS:
 
 @[youtube](FX_AXNDsZ9k)
 
-## UnixFS
+## Unix File System (UnixFS)
 
 A file in IPFS isn’t just content. It might be too big to fit in a single block, so it needs metadata to link all its blocks together. It might be a symlink or a directory, so it needs metadata to link to other files. UnixFS is the data format used to represent files and all their links and metadata in IPFS, and is loosely based on how files work in Unix. When you add a _file_ to IPFS, you are creating a block (or a tree of blocks) in the UnixFS format.
 

--- a/docs/essentials/glossary.md
+++ b/docs/essentials/glossary.md
@@ -5,4 +5,4 @@ sidebarDepth: 0
 
 # IPFS glossary
 
-## This content is still preparing for liftoff.
+> This content is still preparing for liftoff.

--- a/docs/essentials/hashing.md
+++ b/docs/essentials/hashing.md
@@ -2,7 +2,7 @@
 title: Hashing
 ---
 
-# Cryptographic hashing
+# Hashing
 
 ::: tip
 If you're interested in how cryptographic hashes fit into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
@@ -38,7 +38,7 @@ For example, the SHA-256 hash of "Hello world" from above can be represented as 
 mtwirsqawjuoloq2gvtyug2tc3jbf5htm2zeo4rsknfiv3fdp46a
 ```
 
-## Why hashes are important
+## Hashes are important
 
 Cryptographic hashes come with a couple of very important characteristics:
 

--- a/docs/essentials/how-ipfs-works.md
+++ b/docs/essentials/how-ipfs-works.md
@@ -64,7 +64,7 @@ You’ve discovered your content, and you’ve found the current location(s) of 
 
 There are [other content replication protocols under discussion](https://github.com/ipfs/camp/blob/master/DEEP_DIVES/24-replication-protocol.md) as well, the most developed of which is [_Graphsync_](https://github.com/ipld/specs/blob/master/block-layer/graphsync/graphsync.md). There's also a proposal under discussion to [extend the Bitswap protocol](https://github.com/ipfs/go-bitswap/issues/186) to add functionality around requests and responses.
 
-### A note on libp2p
+### Libp2p
 
 What makes libp2p especially useful for peer to peer connections is _connection multiplexing_. Traditionally, every service in a system would open a different connection to remotely communicate with other services of the same kind. Using IPFS, you open just one connection, and you multiplex everything on that. For everything your peers need to talk to each other about, you send a little bit of each thing, and the other end knows how to sort those chunks where they belong.
 

--- a/docs/essentials/immutability.md
+++ b/docs/essentials/immutability.md
@@ -5,6 +5,4 @@ sidebarDepth: 0
 
 # Immutability
 
-## This content is still preparing for liftoff.
-
-In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=Z5zNPwMDYGg) on why immutability is important to how IPFS deals with files.
+> This content is still preparing for liftoff. In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=Z5zNPwMDYGg) on why immutability is important to how IPFS deals with files.

--- a/docs/essentials/ipfs-gateway.md
+++ b/docs/essentials/ipfs-gateway.md
@@ -5,6 +5,4 @@ sidebarDepth: 0
 
 # IPFS Gateway
 
-## This content is still preparing for liftoff.
-
-Consider starting with some basic content from (or at least linking to) [https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md](https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md).
+> This content is still preparing for liftoff. Consider starting with some basic content from (or at least linking to) [https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md](https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md).

--- a/docs/essentials/ipld.md
+++ b/docs/essentials/ipld.md
@@ -5,4 +5,4 @@ sidebarDepth: 0
 
 # The InterPlanetary Linked Data (IPLD) model
 
-## This content is still preparing for liftoff.
+> This content is still preparing for liftoff.

--- a/docs/essentials/ipns.md
+++ b/docs/essentials/ipns.md
@@ -4,8 +4,6 @@ title: IPNS
 
 # InterPlanetary Name System (IPNS)
 
-## IPNS in brief
-
 The InterPlanetary Name System (IPNS) is a system for creating and updating mutable links to IPFS content. Since objects in IPFS are [content addressed](/essentials/content-addressing/), an object's address changes every time an object's content changes. That’s useful for a variety of things, but it makes it hard to get the latest version of something.
 
 A _name_ in IPNS is the [hash](/essentials/hashing) of a public key. It is associated with a record containing information about the hash it links to that is signed by the corresponding private key. New records can be signed and published at any time.
@@ -16,7 +14,7 @@ When looking up an IPNS address, use the `/ipns/` prefix:
 /ipns/QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd
 ```
 
-## An example
+## Example IPNS Set Up
 
 Imagine you want to publish your website under IPFS. You can use the [Files API](/essentials/file-systems/#mutable-file-system-mfs) to publish your static website, and then you'll get a CID you can link to. But when you need to make a change, a problem arises: you get a new CID because you now have different content. And it is not possible for you to be always giving others the new address.
 

--- a/docs/essentials/ipns.md
+++ b/docs/essentials/ipns.md
@@ -14,7 +14,7 @@ When looking up an IPNS address, use the `/ipns/` prefix:
 /ipns/QmSrPmbaUKA3ZodhzPWZnpFgcPMFWF4QsxXbkWfEptTBJd
 ```
 
-## Example IPNS Set Up
+## Example IPNS Setup
 
 Imagine you want to publish your website under IPFS. You can use the [Files API](/essentials/file-systems/#mutable-file-system-mfs) to publish your static website, and then you'll get a CID you can link to. But when you need to make a change, a problem arises: you get a new CID because you now have different content. And it is not possible for you to be always giving others the new address.
 

--- a/docs/essentials/libp2p.md
+++ b/docs/essentials/libp2p.md
@@ -5,6 +5,4 @@ sidebarDepth: 0
 
 # The libp2p protocol
 
-## This content is still preparing for liftoff.
-
-However, we should think about possibly duplicating/excerpting items from [https://docs.libp2p.io/](docs.libp2p.io).
+> This content is still preparing for liftoff.

--- a/docs/essentials/merkle-dag.md
+++ b/docs/essentials/merkle-dag.md
@@ -8,10 +8,6 @@ title: Merkle DAGs
 If you're interested in how Merkle DAGs fit into how IPFS works with files in general, check out this video from IPFS Camp 2019! [Core Course: How IPFS Deals With Files](https://www.youtube.com/watch?v=Z5zNPwMDYGg)
 :::
 
-A _Direct Acyclic Graph_ (DAG) is a type of graph in which edges have direction and cycles are not allowed. For example, a linked list like _A→B→C_ is an instance of a DAG where _A_ references _B_ and so on. We say that _B_ is _a child_ or _a descendant of A_, and that _node A has a link to B_. Conversely _A_ is a _parent of B_. We call nodes that are not children to any other node in the DAG _root nodes_.
-
-## Merkle DAGs in brief
-
 A Merkle DAG is a DAG where each node has an identifier and this is the result of hashing the node’s contents — any opaque payload carried by the node and the list of identifiers of its children — using a cryptographic hash function like SHA256. This brings some important considerations:
 
 - Merkle DAGs can only be constructed from the leaves, that is, from nodes without children. Parents are added after children because the children’s identifiers must be computed in advance to be able to link them.

--- a/docs/essentials/usage-ideas-examples.md
+++ b/docs/essentials/usage-ideas-examples.md
@@ -5,4 +5,4 @@ sidebarDepth: 0
 
 # Usage ideas and examples
 
-## This content is still preparing for liftoff.
+> This content is still preparing for liftoff.

--- a/docs/essentials/what-is-ipfs.md
+++ b/docs/essentials/what-is-ipfs.md
@@ -2,12 +2,6 @@
 title: What is IPFS?
 ---
 
-# What is IPFS?
-
-Welcome! If you’re new to IPFS — the InterPlanetary File System — you’ve come to the right place. Here is a quick overview of what IPFS is, how it works, and how to use it.
-
-## IPFS, defined
-
 Let's just start with a one-line definition of IPFS:
 
 **IPFS is a distributed system for storing and accessing files, websites, applications, and data.**
@@ -32,7 +26,7 @@ And, when you use IPFS, you don’t just download files from someone else — yo
 
 IPFS makes this possible for not only web pages, but also any kind of file a computer might store, whether it’s a document, an email, or even a database record.
 
-## Why decentralization matters
+## Decentralization
 
 Making it possible to download a file from many locations that aren’t managed by one organization…
 
@@ -42,7 +36,7 @@ Making it possible to download a file from many locations that aren’t managed 
 
 That last point is actually where IPFS gets its full name: the **InterPlanetary File System**. We’re striving to build a system that works across places as disconnected or as far apart as planets. While that's an idealistic goal, it keeps us working and thinking hard, and most everything we create in pursuit of that goal is also useful here at home.
 
-## Why content addressing matters
+## Content addressing
 
 What about that link to the aardvark page above? It looked a little unusual:
 
@@ -75,7 +69,7 @@ Of course, people want to update and change content all the time, and don’t wa
 
 It’s important to remember in all of these situations, using IPFS is participatory and collaborative. If nobody using IPFS has the content identified by a given address available for others to access, you won’t be able to get it. On the other hand, content can’t be removed from IPFS as long as _someone_ is interested enough to make it available, whether that person is the original author or not. Note that this is similar to the current web, where it is also impossible to remove content that's been copied across an unknowable number websites; the difference with IPFS is that you are always able to find those copies.
 
-## Why participation matters
+## Participation
 
 While there’s lots of complex technology in IPFS, the fundamental ideas are about changing how networks of people and computers communicate. Today’s World Wide Web is structured on _ownership_ and _access_, meaning that you get files from whoever owns them — if they choose to grant you access. IPFS is based on the ideas of _possession_ and _participation_, where many people _possess_ each others’ files and _participate_ in making them available.
 

--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -18,7 +18,7 @@ This document is a guide to how to address IPFS content paths on the web.
 
 Gateways are provided strictly for convenience: in other words, they help tools that speak HTTP but do not speak distributed protocols such as IPFS. They are the first stage of the upgrade path for the web.
 
-### Centralization concerns
+### Centralization
 
 HTTP gateways have worked well since 2015, but they come with a significant set of limitations related both to the centralized nature of HTTP and some of HTTP's semantics. Location-based addressing of a gateway depends on both DNS and HTTPS/TLS, which relies on a trust in [certificate authorities](https://en.wikipedia.org/wiki/Certificate_authority) (CAs) and [public key infrastructure](https://en.wikipedia.org/wiki/Public_key_infrastructure) (PKI). In the long term, these issues should be mitigated by use of opportunistic protocol upgrade schemes.
 
@@ -74,8 +74,6 @@ Example: [https://docs.ipfs.io](https://docs.ipfs.io) (this website)
 
 For a more complete DNSLink guide, including tutorials, usage examples and FAQs, check out [dnslink.io](https://dnslink.io).
 
----
-
 ## Native URLs
 
 Subdomain convention can be replaced with a native handler. The IPFS URL protocol scheme follows the same requirement of case-insensitive CIDv1 in Base32 as subdomains:
@@ -101,8 +99,6 @@ ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/wiki/Vincent_
   Support for case-insensitive IPNS roots  is a <a href="https://github.com/ipfs/go-ipfs/issues/5287" target="_blank">work in progress&nbsp;<i class="fas fa-external-link-square-alt fa-sm"></i></a>.
 </aside>
 
----
-
 ## Further resources
 
 ### Technical specification for implementers
@@ -120,9 +116,9 @@ browser extension that simplifies access to IPFS resources.
 
 It provides support for native URLs and will automatically redirect IPFS gateway requests to your local daemon so that you are not relying on, or trusting, remote gateways.
 
-### Future: Shared dweb namespace
+### Shared dweb namespace
 
-The distributed web community is exploring the idea of a shared `dweb` namespace to remove the complexity of addressing IPFS and other content-addressed protocols. Currently investigated approaches include:
+This concept isn't yet built, but may be explored and experimented with in the future. The distributed web community is exploring the idea of a shared `dweb` namespace to remove the complexity of addressing IPFS and other content-addressed protocols. Currently investigated approaches include:
 
 - `dweb://` protocol handler ([arewedistributedyet/issues/28](https://github.com/arewedistributedyet/arewedistributedyet/issues/28))
 - `.dweb` special-use top-level domain name ([arewedistributedyet/issues/34](https://github.com/arewedistributedyet/arewedistributedyet/issues/34))

--- a/docs/how-to/browser-tools-frameworks.md
+++ b/docs/how-to/browser-tools-frameworks.md
@@ -1,8 +1,8 @@
 ---
-title: Use browser tools & frameworks
+title: Browser Tools and Frameworks
 ---
 
-# Using browser implementation tools and frameworks
+# Browser Tools and Frameworks
 
 Want to learn how to use IPFS in combination with your favorite framework or browser implementation tool? See below for some common examples, including hints and boilerplate code. Don't see your framework or tool of choice here? Let us know by [filing an issue](https://github.com/ipfs/docs/issues/new?assignees=&labels=OKR+3%3A+Content+Improvement%2C+docs-ipfs&template=content-request.md&title=%5BCONTENT+REQUEST%5D+%20Browser%20Implementation%20Tools%20and%20Frameworks) in the IPFS docs GitHub repo.
 

--- a/docs/how-to/command-line-quick-start.md
+++ b/docs/how-to/command-line-quick-start.md
@@ -12,9 +12,9 @@ Don’t want to use the command line right now? Give the desktop-app implementat
 
 ## Install IPFS
 
-You can install IPFS via a variety of methods — it's simplest to install from a prebuilt package, but feel free to take your pick from the options below.
+You can install IPFS via a variety of methods — it's simplest to install from a [prebuilt package](#prebuilt-package), but you can also install it through the [command-line](#command-line), or by [building everything from source](#building-from-source)
 
-### Installing from a prebuilt package
+### Prebuilt package
 
 First, [download IPFS for your platform](https://dist.ipfs.io/#go-ipfs).
 
@@ -38,7 +38,7 @@ USAGE:
 ...
 ```
 
-### Installing from the command line
+### Command line
 
 If you want to install from the command line, use `ipfs-update`. That way, you can install the IPFS binary now and upgrade it whenever you wish.
 
@@ -84,11 +84,15 @@ If you want, you can also build IPFS from source. For more detailed instructions
 ::: tip
 **Already have IPFS installed, but need to upgrade?** Note that upgrades (and downgrades) may involve a repository upgrade process performed by the [fs-repo-migrations](https://dist.ipfs.io/#fs-repo-migrations) tool.
 
-#### Upgrading using ipfs-update
+#### Updade IPFS
+
+You can upate IPFS using the [built-in tool](#ipfs-update), or by editing the files [manually](#upgrade-manually).
+
+#### IPFS-Update
 
 `ipfs-update install` will download and run `fs-repo-migrations` when needed, during the installation of a newer or older `ipfs` version (as explained above). This is the easiest way of upgrading, but it's **important** to make sure that the IPFS daemon is not running during an upgrade.
 
-#### Upgrading manually
+#### Upgrade manually
 
 To upgrade manually, you will also need to manually run any repository migrations as follows:
 

--- a/docs/how-to/command-line-quick-start.md
+++ b/docs/how-to/command-line-quick-start.md
@@ -84,7 +84,7 @@ If you want, you can also build IPFS from source. For more detailed instructions
 ::: tip
 **Already have IPFS installed, but need to upgrade?** Note that upgrades (and downgrades) may involve a repository upgrade process performed by the [fs-repo-migrations](https://dist.ipfs.io/#fs-repo-migrations) tool.
 
-#### Updade IPFS
+#### Update/upgrade IPFS
 
 You can upate IPFS using the [built-in tool](#ipfs-update), or by editing the files [manually](#upgrade-manually).
 

--- a/docs/how-to/configure-node.md
+++ b/docs/how-to/configure-node.md
@@ -2,7 +2,7 @@
 title: Configure a node
 ---
 
-# Configure an IPFS node
+# Configure a node
 
 IPFS is configured through a json formatted text file, located by default at `~/.ipfs/config`.
 
@@ -10,7 +10,7 @@ IPFS is configured through a json formatted text file, located by default at `~/
 
 The config file stores a few different address types, all of which use the multiaddr addressing format. Lets go over what each address type means.
 
-```
+```json
 "Addresses": {
     "Swarm": [
       "/ip4/0.0.0.0/tcp/4001"
@@ -39,5 +39,3 @@ The mounts config values specifies the default mount points for the IPFS and ipn
 ## Bootstrap
 
 The Bootstrap config array specifies the list of IPFS peers that your daemon will connect to on startup. The default values for this are the 'ipfs solarnet' nodes, which are a set of VPS servers distributed around the country.
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/how-to/host-git-style-repo.md
+++ b/docs/how-to/host-git-style-repo.md
@@ -2,7 +2,7 @@
 title: Host a Git-style repo
 ---
 
-# Host a Git-style repo on IPFS
+# Host a Git-style repo
 
 Have you ever said to yourself: "Man, my Git server isn't distributed enough" or "I wish I had an easy way to serve a static Git repository worldwide". Well, wish no more.
 
@@ -10,25 +10,25 @@ In this gude, we discuss how to serve a Git repository through the IPFS network.
 
 To start, select a Git repository you want to host, and do a bare clone of it:
 
-```
-$ git clone --bare git@myhost.io/myrepo
+```bash
+git clone --bare git@myhost.io/myrepo
 ```
 
 For those who aren't super Git-savvy, a bare repository means that it doesn't have a working tree, and can be used as a server. They have a slightly different format than your normal Git repository.
 
 Now, to get it ready to be cloned, you need to do the following:
 
-```
-$ cd myrepo
-$ git update-server-info
+```bash
+cd myrepo
+git update-server-info
 ```
 
 Optionally, you can unpack all of Git's objects:
 
 ```
-$ cp objects/pack/*.pack .
-$ git unpack-objects < ./*.pack
-$ rm ./*.pack
+cp objects/pack/*.pack .
+git unpack-objects < ./*.pack
+rm ./*.pack
 ```
 
 Doing this breaks up Git's large packfile into all of its individual objects. This will allow IPFS to deduplicate objects if you add multiple versions of this Git repository.
@@ -76,5 +76,3 @@ import (
 And you will be guaranteed to have the same code every time!
 
 Note: Since Go doesn't allow the usage of localhost for import paths, we use the public HTTP gateways. This provides no security guarantees, as a man-in-the-middle attack could ship you bad code. You could use a domain name that redirects to the localhost instead to avoid the issue.
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/how-to/host-single-page-site.md
+++ b/docs/how-to/host-single-page-site.md
@@ -40,7 +40,7 @@ To view it from another ipfs node, you can try `http://gateway.ipfs.io/ipfs/$SIT
 
 Those hashes are difficult to remember. Let's look at some ways to get rid of them.
 
-## Edit your DNS Records
+## Edit your DNS records
 
 Assume you have the domain name `your.domain` and can access your registrar's control panel to manage DNS entries for it.
 

--- a/docs/how-to/host-single-page-site.md
+++ b/docs/how-to/host-single-page-site.md
@@ -84,7 +84,7 @@ Return to your registrar's control panel, change the DNS TXT record with the key
 
 **Note:** When using IPNS to update websites, assets may be loaded from two different resolved hashes while the update propagates. This may result in outdated URLs or missing assets until the update has completely propagated.
 
-## Point Your Domain to IPFS
+## Point your domain to IPFS
 
 You now have a website on ipfs/ipns, but your visitors can't access it at `http://your.domain`.
 

--- a/docs/how-to/host-single-page-site.md
+++ b/docs/how-to/host-single-page-site.md
@@ -40,7 +40,7 @@ To view it from another ipfs node, you can try `http://gateway.ipfs.io/ipfs/$SIT
 
 Those hashes are difficult to remember. Let's look at some ways to get rid of them.
 
-## DNS TXT records as shortcuts
+## Edit your DNS Records
 
 Assume you have the domain name `your.domain` and can access your registrar's control panel to manage DNS entries for it.
 
@@ -84,7 +84,7 @@ Return to your registrar's control panel, change the DNS TXT record with the key
 
 **Note:** When using IPNS to update websites, assets may be loaded from two different resolved hashes while the update propagates. This may result in outdated URLs or missing assets until the update has completely propagated.
 
-## Point your.domain to IPFS
+## Point Your Domain to IPFS
 
 You now have a website on ipfs/ipns, but your visitors can't access it at `http://your.domain`.
 
@@ -113,7 +113,3 @@ Alternatively, it is possible to use CNAME records to point at the DNS records o
 However you will need to change the key for the TXT record from `your.domain` to `_dnslink.your.domain`.
 
 So by creating a CNAME for `your.domain` to `gateway.ipfs.io` and adding a `_dnslink.your.domain` record with `dnslink=/ipns/<your peer id>` you can host your website without explicitly referring to IP addresses of the ipfs gateway.
-
-Happy hacking!
-
-_By [Whyrusleeping](https://github.com/whyrusleeping) and [Emma Humphries](https://github.com/emceeaich)_

--- a/docs/how-to/make-service.md
+++ b/docs/how-to/make-service.md
@@ -2,13 +2,13 @@
 title: Make a service
 ---
 
-# Make your own IPFS service
+# Make a service
 
 IPFS has a few default services that it runs by default, such as the dht, bitswap, and the diagnostics service. Each of these simply registers a handler on the IPFS PeerHost, and listens on it for new connections. The `corenet` package has a very clean interface to this functionality. So let's try building an easy demo service to try this out!
 
 Let's start by building the service host:
 
-```
+```go
 package main
 
 import (
@@ -26,7 +26,7 @@ We don't need too many imports for this. Now, the only other thing we need is ou
 
 Set up an IPFS node.
 
-```
+```go
 func main() {
 	// Basic ipfsnode setup
 	r, err := fsrepo.Open("~/.ipfs")
@@ -53,7 +53,7 @@ That's just the basic template of code to initiate a default IPFS node from the 
 
 Next, we are going to build our service.
 
-```
+```go
 	list, err := corenet.Listen(nd, "/app/whyrusleeping")
 	if err != nil {
 		panic(err)
@@ -80,7 +80,7 @@ And that's really all you need to write a service on top of IPFS. When a client 
 
 Now we need a client to connect to us:
 
-```
+```go
 package main
 
 import (
@@ -142,16 +142,16 @@ This client will set up their IPFS node (note: this is moderately expensive and 
 
 To try it out, run the following on one computer:
 
-```
-$ ipfs init # if you havent already
-$ go run host.go
+```bash
+ipfs init # if you havent already
+go run host.go
 ```
 
 That should print out that peer's ID, copy it and use it on a second machine:
 
-```
-$ ipfs init # if you havent already
-$ go run client.go <peerID>
+```bash
+ipfs init # if you havent already
+go run client.go <peerID>
 ```
 
 It should print out `Hello! This is whyrusleepings awesome ipfs service`
@@ -161,5 +161,3 @@ Now, you might be asking yourself: "Why would I use this? How is it better than 
 1. You dial a specific peerID, no matter what their IP address happens to be at the moment.
 2. You take advantage of the NAT traversal built into our net package.
 3. Instead of a 'port' number, you get a much more meaningful protocol ID string.
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/how-to/modify-bootstrap-list.md
+++ b/docs/how-to/modify-bootstrap-list.md
@@ -8,17 +8,17 @@ The IPFS bootstrap list is a list of peers with which the IPFS daemon learns abo
 
 First, let's list your node's bootstrap list:
 
-```
-> ipfs bootstrap list
-/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
-/ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx
-/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
-/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLpPVmHKQ4XTPdz8tjDFgdeRFkpV8JgYq8JVJ69RrZm
-/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64
-/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu
-/ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm
-/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd
-/ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3
+```bash
+ipfs bootstrap list
+> /ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
+> /ip4/104.236.151.122/tcp/4001/ipfs/QmSoLju6m7xTh3DuokvT3886QRYqxAzb1kShaanJgW36yx
+> /ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
+> /ip4/104.236.179.241/tcp/4001/ipfs/QmSoLpPVmHKQ4XTPdz8tjDFgdeRFkpV8JgYq8JVJ69RrZm
+> /ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64
+> /ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu
+> /ip4/162.243.248.213/tcp/4001/ipfs/QmSoLueR4xBeUbY9WZ9xGUUxunbKWcrNFTDAadQJmocnWm
+> /ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd
+> /ip4/178.62.61.185/tcp/4001/ipfs/QmSoLMeWqB7YGVLJN3pNLQpmmEk35v6wYtsMGLzSr5QBU3
 ```
 
 The lines listed above are the addresses of the default IPFS bootstrap nodes -- they are run by the IPFS development team. The addresses listed are fully resolved and specified in [multiaddr](https://github.com/multiformats/multiaddr) format, which makes every protocol explicit. This way, your node knows exactly where to reach the bootstrap nodes -- the location is unambiguous.
@@ -27,39 +27,37 @@ Don't change this list unless you understand what it means to do so. Bootstrappi
 
 Here, we add a new peer to the bootstrap list:
 
-```
-> ipfs bootstrap add /ip4/25.196.147.100/tcp/4001/ipfs/QmaMqSwWShsPg2RbredZtoneFjXhim7AQkqbLxib45Lx4S
+```bash
+ipfs bootstrap add /ip4/25.196.147.100/tcp/4001/ipfs/QmaMqSwWShsPg2RbredZtoneFjXhim7AQkqbLxib45Lx4S
 ```
 
 Here, we remove a node from the bootstrap list:
 
-```
-> ipfs bootstrap rm /ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu
+```bash
+ipfs bootstrap rm /ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu
 ```
 
 Let's say we want to create a backup of our new bootstrap list. We can easily do this by redirecting stdout of `ipfs bootstrap list` to a file:
 
-```
-> ipfs bootstrap list >save
+```bash
+ipfs bootstrap list >save
 ```
 
 If we ever want to start from scratch, we can delete the entire bootstrap list at once:
 
-```
-> ipfs bootstrap rm --all
+```bash
+ipfs bootstrap rm --all
 ```
 
 With an empty list, we can restore the default bootstrap list:
 
-```
-> ipfs bootstrap add --default
+```bash
+ipfs bootstrap add --default
 ```
 
 Remove the entire bootstrap list again, and restore our saved one by piping the contents of the saved file to `ipfs bootstrap add`:
 
+```bash
+ipfs bootstrap rm --all
+cat save | ipfs bootstrap add
 ```
-> ipfs bootstrap rm --all
-> cat save | ipfs bootstrap add
-```
-
-_By [jbenet](http://github.com/jbenet) and [insanity54](http://github.com/insanity54)_

--- a/docs/how-to/observe-peers.md
+++ b/docs/how-to/observe-peers.md
@@ -2,7 +2,7 @@
 title: Observe peers
 ---
 
-# Observe peers on the network
+# Observe peers
 
 Included in IPFS are a useful set of commands to aid in observing the network.
 
@@ -23,5 +23,3 @@ Search for a given peer on the network:
 ```sh
 ipfs dht findpeer QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z
 ```
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/how-to/pin-files.md
+++ b/docs/how-to/pin-files.md
@@ -4,8 +4,6 @@ title: Pin files
 
 # Pin files using IPFS
 
-## About pinning
-
 Pinning is a very important concept in IPFS. IPFS semantics try to make it feel like every single object is local — there is no "retrieve this file for me from a remote server", just `ipfs cat` or `ipfs get`, which act the same way no matter where the actual object is located. While this is nice, sometimes you want to be able to control what you keep around. Pinning is the mechanism that allows you to tell IPFS to always keep a given object local. IPFS has a fairly aggressive caching mechanism that will keep an object local for a short time after you perform any IPFS operation on it, but these objects may get garbage-collected fairly regularly. To prevent that garbage collection, simply pin the hash you care about. Objects added through `ipfs add` are pinned recursively by default.
 
 ```
@@ -27,7 +25,7 @@ As you may have noticed, the first `ipfs pin rm` command didn't work — it shou
 
 A pinned object cannot be garbage-collected — try this for proof:
 
-```
+```bash
 ipfs add foo
 ipfs repo gc
 ipfs cat <foo hash>
@@ -35,10 +33,8 @@ ipfs cat <foo hash>
 
 But if `foo` were to somehow become unpinned ...
 
-```
+```bash
 ipfs pin rm -r <foo hash>
 ipfs repo gc
 ipfs cat <foo hash>
 ```
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/how-to/store-play-videos.md
+++ b/docs/how-to/store-play-videos.md
@@ -2,11 +2,11 @@
 title: Store & play videos
 ---
 
-# Store and play videos using IPFS
+# Store and play videos
 
 IPFS can be used to store and play videos. Suppose we add a video:
 
-```
+```bash
 ipfs add -q sintel.mp4 | tail -n1
 ```
 
@@ -14,20 +14,18 @@ You can view the resulting hash in a few different ways.
 
 On the command line:
 
-```
+```bash
 ipfs cat $vidhash | mplayer -vo xv -
 ```
 
 Via local gateway (note that the gateway method works with most video players and browsers):
 
-```
+```bash
 mplayer http://localhost:8080/ipfs/$vidhash
 ```
 
 Or open it up in a browser tab (in this example, Chrome):
 
-```
+```bash
 chromium http://localhost:8080/ipfs/$vidhash
 ```
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/how-to/take-snapshot.md
+++ b/docs/how-to/take-snapshot.md
@@ -2,51 +2,49 @@
 title: Take a snapshot
 ---
 
-# Take and store a snapshot using IPFS
+# Take a snapshot
 
 Let's take a quick look at how IPFS can be used to take basic _snapshots_ of files — an action that enables you to access those files later in the same state as they were when you "snapshotted" them.
 
 Save your directory:
 
-```
-$ ipfs add -r ~/code/myproject
+```bash
+ipfs add -r ~/code/myproject
 ```
 
 Note the hash:
 
-```
-$ echo $hash `date` >> snapshots
+```bash
+echo $hash `date` >> snapshots
 ```
 
 Or all at once:
 
-```
-$ echo `ipfs add -q -r ~/code/myproject | tail -n1` `date` >> snapshots
+```bash
+echo `ipfs add -q -r ~/code/myproject | tail -n1` `date` >> snapshots
 ```
 
 (Note: the `-q` makes the output only contain the hashes, and piping through `tail -n1` ensures that only the hash of the top folder is output.)
 
 Make sure to have the placeholders for the mount points:
 
-```
-$ sudo mkdir /ipfs /ipns
-$ sudo chown `whoami` /ipfs /ipns
+```basg
+sudo mkdir /ipfs /ipns
+sudo chown `whoami` /ipfs /ipns
 ```
 
 You will need to have `FUSE` (Filesystem in Userspace) installed on your machine in order to be able to `mount` directories from the ipfs. You can find instructions for how to install `FUSE` [in the `go-ipfs` docs](https://github.com/ipfs/go-ipfs/blob/master/docs/fuse.md).
 
 View your snapshots live:
 
-```
-$ ipfs mount
-$ ls /ipfs/$hash/
+```bash
+ipfs mount
+ls /ipfs/$hash/
 
-# can also
+# Or
 
-$ cd /ipfs/$hash/
-$ ls
+cd /ipfs/$hash/
+ls
 ```
 
 Through the FUSE interface, you'll be able to access your files exactly as they were when you took the snapshot.
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/how-to/work-with-blocks.md
+++ b/docs/how-to/work-with-blocks.md
@@ -4,38 +4,36 @@ title: Work with blocks
 
 # Work with blocks
 
-## Blocks in brief
-
 The `ipfs add` command will create a Merkle DAG out of the data in the files you specify. It follows the [unixfs data format](https://github.com/ipfs/go-unixfs/blob/master/pb/unixfs.proto) when doing this. This means that your files are broken down into blocks, and then arranged in a tree-like structure using 'link nodes' to tie them together. A given file's 'hash' is actually the hash of the root (uppermost) node in the DAG. For a given DAG, you can easily view the sub-blocks under it with `ipfs ls`.
 
 For example:
 
-```
-# ensure this file is larger than 256k
+```bash
+# Ensure this file is larger than 256k.
 ipfs add alargefile
 ipfs ls thathash
 ```
 
 The above command should print out something like:
 
-```
+```bash
 ipfs@earth ~> ipfs ls qms2hjwx8qejwm4nmwu7ze6ndam2sfums3x6idwz5myzbn
-qmv8ndh7ageh9b24zngaextmuhj7aiuw3scc8hkczvjkww 7866189
-qmuvjja4s4cgyqyppozttssquvgcv2n2v8mae3gnkrxmol 7866189
-qmrgjmlhlddhvxuieveuuwkeci4ygx8z7ujunikzpfzjuk 7866189
-qmrolalcquyo5vu5v8bvqmgjcpzow16wukq3s3vrll2tdk 7866189
-qmwk51jygpchgwr3srdnmhyerheqd22qw3vvyamb3emhuw 5244129
+> qmv8ndh7ageh9b24zngaextmuhj7aiuw3scc8hkczvjkww 7866189
+> qmuvjja4s4cgyqyppozttssquvgcv2n2v8mae3gnkrxmol 7866189
+> qmrgjmlhlddhvxuieveuuwkeci4ygx8z7ujunikzpfzjuk 7866189
+> qmrolalcquyo5vu5v8bvqmgjcpzow16wukq3s3vrll2tdk 7866189
+> qmwk51jygpchgwr3srdnmhyerheqd22qw3vvyamb3emhuw 5244129
 ```
 
 This shows all of the immediate sub-blocks of your file, as well as the size of them and their children on the disk.
 
-## What to do with blocks?
+## What to do with blocks
 
 If you feel adventurous, you can get a lot of different information out of these different blocks. You can use the sub-block hashes as input to `ipfs cat` to see only the data in any given sub-tree (the data of that block and its children). To see just the data of a given block and not its children, use `ipfs block get`. But be careful, as `ipfs block get` on an intermediate block will print out the raw binary data of its DAG structure to your screen.
 
 The command `ipfs block stat` will tell you the exact size of a given block (without its children), and `ipfs refs` will tell you all the children of that block. Similarly, `ipfs ls` or `ipfs object links` will show you all children and their sizes. `ipfs refs` is a more suitable command for scripting something to run on each child block of a given object.
 
-## Blocks vs. objects
+## Blocks vs objects
 
 In IPFS, a block refers to a single unit of data, identified by its key (hash). A block can be any sort of data, and does not necessarily have any sort of format associated with it. An object, on the other hand, refers to a block that follows the Merkle DAG protobuf data format. It can be parsed and manipulated via the `ipfs object` command. Any given hash may represent an object or a block.
 
@@ -43,13 +41,12 @@ In IPFS, a block refers to a single unit of data, identified by its key (hash). 
 
 Creating your own blocks is easy! Simply put your data in a file and run `ipfs block put <yourfile>` on it. Or you can pipe your file data into `ipfs block put`, like so:
 
-```
-$ echo "This is some data" | ipfs block put
-QmfQ5QAjvg4GtA3wg3adpnDJug8ktA1BxurVqBD8rtgVjM
-$ ipfs block get QmfQ5QAjvg4GtA3wg3adpnDJug8ktA1BxurVqBD8rtgVjM
-This is some data
+```bash
+echo "This is some data" | ipfs block put
+> QmfQ5QAjvg4GtA3wg3adpnDJug8ktA1BxurVqBD8rtgVjM
+
+ipfs block get QmfQ5QAjvg4GtA3wg3adpnDJug8ktA1BxurVqBD8rtgVjM
+> This is some data
 ```
 
 Note: When making your own block data, you won't be able to read the data with `ipfs cat`. This is because you are inputting raw data without the unixfs data format. To read raw blocks, use `ipfs block get` as shown in the example.
-
-_By [whyrusleeping](http://github.com/whyrusleeping)_

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,5 +1,5 @@
 ---
-title: Install IPFS ✨
+title: Install IPFS
 sidebarDepth: 0
 ---
 

--- a/docs/project/history.md
+++ b/docs/project/history.md
@@ -5,6 +5,4 @@ sidebarDepth: 0
 
 # History of the IPFS project
 
-## This content is still preparing for liftoff.
-
-Note, however, that this document should eventually live on the main ipfs.io site. Make sure this links elegantly to the original IPFS whitepaper.
+> This content is still preparing for liftoff.

--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -1,5 +1,5 @@
 ---
-title: Related Protocol Labs projects
+title: Related projects
 ---
 
 # Related projects

--- a/docs/support-community/irc.md
+++ b/docs/support-community/irc.md
@@ -2,7 +2,7 @@
 title: IRC
 ---
 
-# IRC
+# Internet Relay Chat (IRC)
 
 If IRC is your go-to for discussions and help on dev topics, there are several IRC channels on Freenode dedicated to IPFS, and it’s a great place for live chat:
 

--- a/docs/support-community/irc.md
+++ b/docs/support-community/irc.md
@@ -13,7 +13,7 @@ If IRC is your go-to for discussions and help on dev topics, there are several I
 
 For longer-lived discussions and for support, please use the discussion forums at [https://discuss.ipfs.io](https://discuss.ipfs.io) instead of IRC! It’s easy for complex discussions to get lost in a sea of new messages on IRC, and posting longer discussions and support requests on the forums helps future visitors, too.
 
-## New to IRC
+## Getting started with IRC
 
 If you’re new to IRC, there are _lots_ of mobile and desktop clients for working with it. Here are a few to get you started:
 

--- a/docs/support-community/irc.md
+++ b/docs/support-community/irc.md
@@ -2,18 +2,18 @@
 title: IRC
 ---
 
-# IPFS on Internet Relay Chat (IRC)
+# IRC
 
 If IRC is your go-to for discussions and help on dev topics, there are several IRC channels on Freenode dedicated to IPFS, and it’s a great place for live chat:
 
 - Use [#ipfs on irc.freenode.org](irc://irc.freenode.org/%23ipfs) for general IPFS usage and community chat
 - Use [#ipfs-dev on irc.freenode.org](irc://irc.freenode.org/%23ipfs-dev) for discussing implementation details, especially if you are contributing code to IPFS
 
-## IRC vs. forums
+## IRC vs forums
 
 For longer-lived discussions and for support, please use the discussion forums at [https://discuss.ipfs.io](https://discuss.ipfs.io) instead of IRC! It’s easy for complex discussions to get lost in a sea of new messages on IRC, and posting longer discussions and support requests on the forums helps future visitors, too.
 
-## New to IRC?
+## New to IRC
 
 If you’re new to IRC, there are _lots_ of mobile and desktop clients for working with it. Here are a few to get you started:
 

--- a/docs/support-community/social-media.md
+++ b/docs/support-community/social-media.md
@@ -3,7 +3,7 @@ title: Social media
 sidebarDepth: 0
 ---
 
-# IPFS on social media
+# Social media
 
 IPFS is everywhere on the internet — and that includes social media. Find your favorite flavor here.
 


### PR DESCRIPTION
Went through all the pages _except_ everything in `reference`. Since that stuff is automated-ish anyway it doesn't make sense to manually go through and modify headers to fit the search function we currently have.

I also cleaned up some weird formatting and code blocks where I saw them, but this is by no means a thorough inspection and fix of all the docs. There's still a bunch of things wrong that I want to fix, but probably in the new year.