### PR TITLE
Add related links to content stubs

### DIFF
--- a/docs/.vuepress/theme/global-components/ContentStatus.vue
+++ b/docs/.vuepress/theme/global-components/ContentStatus.vue
@@ -6,11 +6,7 @@
       </div>
       <h2>{{ title }}</h2>
       <div v-if="issueNum" class="content-status-status">
-        <a
-          target="_blank"
-          :href="`https://github.com/${repo}/issue/${issueNum}`"
-          >Check the status</a
-        >
+        <a target="_blank" :href="`${issueNum}`">Check the status</a>
         of this page on GitHub.
       </div>
       <div class="section content-status-vote">

--- a/docs/.vuepress/theme/global-components/ContentStatus.vue
+++ b/docs/.vuepress/theme/global-components/ContentStatus.vue
@@ -18,7 +18,7 @@
         <h3>Give us a hand</h3>
         <ul>
           <li v-if="issueUrl">
-            <a :href="issueUrl">Help write this page</a>
+            <a target="_blank" :href="issueUrl">Help write this page</a>
           </li>
           <li v-if="$site.themeConfig.betaTestFormUrl">
             <a :href="$site.themeConfig.betaTestFormUrl" target="_blank"

--- a/docs/.vuepress/theme/global-components/ContentStatus.vue
+++ b/docs/.vuepress/theme/global-components/ContentStatus.vue
@@ -5,7 +5,7 @@
         <img src="../assets/pencil-rocket.svg" />
       </div>
       <h2>{{ title }}</h2>
-      <div v-if="issueNum" class="content-status-status">
+      <div v-if="issueUrl" class="content-status-status">
         <a target="_blank" :href="issueUrl">Check the status</a>
         of this page on GitHub.
       </div>
@@ -17,10 +17,8 @@
       <div class="section content-status-info">
         <h3>Give us a hand</h3>
         <ul>
-          <li v-if="issueNum">
-            <a :href="`https://github.com/${repo}/issue/${issueNum}`"
-              >Help write this page</a
-            >
+          <li v-if="issueUrl">
+            <a :href="issueUrl">Help write this page</a>
           </li>
           <li v-if="$site.themeConfig.betaTestFormUrl">
             <a :href="$site.themeConfig.betaTestFormUrl" target="_blank"
@@ -47,8 +45,8 @@
 <script>
 export default {
   computed: {
-    issueNum: function() {
-      return this.$frontmatter && this.$frontmatter.issueNum
+    issueUrl: function() {
+      return this.$frontmatter && this.$frontmatter.issueUrl
     },
     repo: function() {
       return this.$site && this.$site.themeConfig && this.$site.themeConfig.repo

--- a/docs/.vuepress/theme/global-components/ContentStatus.vue
+++ b/docs/.vuepress/theme/global-components/ContentStatus.vue
@@ -6,7 +6,7 @@
       </div>
       <h2>{{ title }}</h2>
       <div v-if="issueNum" class="content-status-status">
-        <a target="_blank" :href="`${issueNum}`">Check the status</a>
+        <a target="_blank" :href="issueUrl">Check the status</a>
         of this page on GitHub.
       </div>
       <div class="section content-status-vote">

--- a/docs/essentials/bitswap.md
+++ b/docs/essentials/bitswap.md
@@ -1,14 +1,13 @@
 ---
 title: Bitswap
 sidebarDepth: 0
-issueNum: 333
+issueNum: https://github.com/ipfs/docs/issues/85
 related:
-  an interesting article: https://ipfs.io
-  another interesting article: https://ipfs.io
+  'Article: Swapping bits and distributing hashes on the decentralized web (Textile)': https://medium.com/textileio/swapping-bits-and-distributing-hashes-on-the-decentralized-web-5da98a3507
+  'GitHub repo: Go Bitswap implementation': https://github.com/ipfs/go-bitswap
+  'GitHub repo: JavaScript Bitswap implementation': https://github.com/ipfs/js-ipfs-bitswap
 ---
 
 # Bitswap
 
 <ContentStatus />
-
-In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=fLUq0RkiTBA) on how Bitswap fits into the overall lifecycle of data in IPFS!

--- a/docs/essentials/bitswap.md
+++ b/docs/essentials/bitswap.md
@@ -1,7 +1,7 @@
 ---
 title: Bitswap
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/docs/issues/85
+issueUrl: https://github.com/ipfs/docs/issues/85
 related:
   'Article: Swapping bits and distributing hashes on the decentralized web (Textile)': https://medium.com/textileio/swapping-bits-and-distributing-hashes-on-the-decentralized-web-5da98a3507
   'GitHub repo: Go Bitswap implementation': https://github.com/ipfs/go-bitswap

--- a/docs/essentials/glossary.md
+++ b/docs/essentials/glossary.md
@@ -1,8 +1,13 @@
 ---
 title: Glossary
 sidebarDepth: 0
+issueNum: https://github.com/ipfs/docs/issues/56
+related:
+  'Guide to libp2p terminology': https://docs.libp2p.io/reference/glossary/
+  'Article: The Decentralized Web Explained in Words You Can Understand (Breaker)': https://breakermag.com/the-decentralized-web-explained-in-words-you-can-understand/
+  'Decentralized Web Primer': https://flyingzumwalt.gitbooks.io/decentralized-web-primer
 ---
 
 # IPFS glossary
 
-> This content is still preparing for liftoff.
+<ContentStatus />

--- a/docs/essentials/glossary.md
+++ b/docs/essentials/glossary.md
@@ -1,7 +1,7 @@
 ---
 title: Glossary
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/docs/issues/56
+issueUrl: https://github.com/ipfs/docs/issues/56
 related:
   'Guide to libp2p terminology': https://docs.libp2p.io/reference/glossary/
   'Article: The Decentralized Web Explained in Words You Can Understand (Breaker)': https://breakermag.com/the-decentralized-web-explained-in-words-you-can-understand/

--- a/docs/essentials/immutability.md
+++ b/docs/essentials/immutability.md
@@ -1,8 +1,14 @@
 ---
 title: Immutability
 sidebarDepth: 0
+issueNum: https://github.com/ipfs/docs/issues/386
+related:
+  'IPFS Docs: Content addressing and CIDs': /essentials/content-addressing/
+  'Video: How IPFS deals with files (IPFS Camp 2019)': https://www.youtube.com/watch?v=Z5zNPwMDYGg
+  'Tutorial: How IPFS deals with files (IPFS Camp 2019)': https://github.com/ipfs/camp/tree/master/CORE_AND_ELECTIVE_COURSES/CORE_COURSE_A
+  'Wikipedia: Content-addressable storage': https://en.wikipedia.org/wiki/Content-addressable_storage
 ---
 
 # Immutability
 
-> This content is still preparing for liftoff. In the meantime, check out [this video from IPFS Camp 2019](https://www.youtube.com/watch?v=Z5zNPwMDYGg) on why immutability is important to how IPFS deals with files.
+<ContentStatus />

--- a/docs/essentials/immutability.md
+++ b/docs/essentials/immutability.md
@@ -1,7 +1,7 @@
 ---
 title: Immutability
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/docs/issues/386
+issueUrl: https://github.com/ipfs/docs/issues/386
 related:
   'IPFS Docs: Content addressing and CIDs': /essentials/content-addressing/
   'Video: How IPFS deals with files (IPFS Camp 2019)': https://www.youtube.com/watch?v=Z5zNPwMDYGg

--- a/docs/essentials/ipfs-gateway.md
+++ b/docs/essentials/ipfs-gateway.md
@@ -1,7 +1,7 @@
 ---
 title: IPFS Gateway
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/docs/issues/93
+issueUrl: https://github.com/ipfs/docs/issues/93
 related:
   'IPFS Docs: Address IPFS on the Web': /how-to/address-ipfs-on-web/
   'IPFS public gateway checker': https://ipfs.github.io/public-gateway-checker/

--- a/docs/essentials/ipfs-gateway.md
+++ b/docs/essentials/ipfs-gateway.md
@@ -1,8 +1,15 @@
 ---
 title: IPFS Gateway
 sidebarDepth: 0
+issueNum: https://github.com/ipfs/docs/issues/93
+related:
+  'IPFS Docs: Address IPFS on the Web': /how-to/address-ipfs-on-web/
+  'IPFS public gateway checker': https://ipfs.github.io/public-gateway-checker/
+  'GitHub repo: Gateway summary from go-ipfs': https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md
+  'Article: Solving the IPFS Gateway Problem (Pinata)': https://medium.com/pinata/the-ipfs-gateway-problem-64bbe7eb8170
+  'Tutorial: Setting up an IPFS gateway on Google Cloud Platform (Stacktical)': https://blog.stacktical.com/ipfs/gateway/dapp/2019/09/21/ipfs-server-google-cloud-platform.html
 ---
 
 # IPFS Gateway
 
-> This content is still preparing for liftoff. Consider starting with some basic content from (or at least linking to) [https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md](https://github.com/ipfs/go-ipfs/blob/master/docs/gateway.md).
+<ContentStatus />

--- a/docs/essentials/ipld.md
+++ b/docs/essentials/ipld.md
@@ -1,7 +1,7 @@
 ---
 title: IPLD
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/docs/issues/86
+issueUrl: https://github.com/ipfs/docs/issues/86
 related:
   'IPLD home page': https://ipld.io/
   'IPLD CID explorer': https://explore.ipld.io/#/explore/QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU

--- a/docs/essentials/ipld.md
+++ b/docs/essentials/ipld.md
@@ -1,8 +1,13 @@
 ---
 title: IPLD
 sidebarDepth: 0
+issueNum: https://github.com/ipfs/docs/issues/86
+related:
+  'IPLD home page': https://ipld.io/
+  'IPLD CID explorer': https://explore.ipld.io/#/explore/QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU
+  'IPLD specifications': https://github.com/ipld/specs
 ---
 
 # The InterPlanetary Linked Data (IPLD) model
 
-> This content is still preparing for liftoff.
+<ContentStatus />

--- a/docs/essentials/libp2p.md
+++ b/docs/essentials/libp2p.md
@@ -1,8 +1,14 @@
 ---
 title: libp2p
 sidebarDepth: 0
+issueNum: https://github.com/ipfs/docs/issues/388
+related:
+  'What is libp2p?': https://docs.libp2p.io/introduction/what-is-libp2p/
+  'Foundational libp2p concepts': https://docs.libp2p.io/concepts/
+  'Getting started with libp2p': https://docs.libp2p.io/tutorials/getting-started/
+  'Examples of libp2p key features': https://docs.libp2p.io/examples/
 ---
 
 # The libp2p protocol
 
-> This content is still preparing for liftoff.
+<ContentStatus />

--- a/docs/essentials/libp2p.md
+++ b/docs/essentials/libp2p.md
@@ -1,7 +1,7 @@
 ---
 title: libp2p
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/docs/issues/388
+issueUrl: https://github.com/ipfs/docs/issues/388
 related:
   'What is libp2p?': https://docs.libp2p.io/introduction/what-is-libp2p/
   'Foundational libp2p concepts': https://docs.libp2p.io/concepts/

--- a/docs/essentials/usage-ideas-examples.md
+++ b/docs/essentials/usage-ideas-examples.md
@@ -1,8 +1,14 @@
 ---
 title: Usage ideas & examples
 sidebarDepth: 0
+issueNum: https://github.com/ipfs/docs/issues/387
+related:
+  'Awesome IPFS: Showcase of projects and tools built on IPFS': https://awesome.ipfs.io/
+  'IPFS Forums: Use cases and applications': https://discuss.ipfs.io/c/ecosystem/applications-of-ipfs
+  'Visualization: IPFS developer use cases and goals': https://app.mural.co/t/protocollabs6957/m/protocollabs6957/1564779785852/cf7669f3c1773508a811a3fa0eadfb99efb310bf
+  "IPFS GitHub repo: Issues labeled 'applications of IPFS'": https://github.com/ipfs/ipfs/labels/applications%20of%20ipfs
 ---
 
 # Usage ideas and examples
 
-> This content is still preparing for liftoff.
+<ContentStatus />

--- a/docs/essentials/usage-ideas-examples.md
+++ b/docs/essentials/usage-ideas-examples.md
@@ -1,7 +1,7 @@
 ---
 title: Usage ideas & examples
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/docs/issues/387
+issueUrl: https://github.com/ipfs/docs/issues/387
 related:
   'Awesome IPFS: Showcase of projects and tools built on IPFS': https://awesome.ipfs.io/
   'IPFS Forums: Use cases and applications': https://discuss.ipfs.io/c/ecosystem/applications-of-ipfs

--- a/docs/project/history.md
+++ b/docs/project/history.md
@@ -1,8 +1,14 @@
 ---
 title: History
 sidebarDepth: 0
+issueNum: https://github.com/ipfs/website/issues/352
+related:
+  'Video: Juan Benet explains the IPFS alpha': https://www.youtube.com/watch?v=skMTdSEaCtA
+  'IPFS draft whitepaper': https://ipfs.io/ipfs/QmR7GSQM93Cx5eAg6a6yRzNde1FQv7uL6X1o4k7zrJa3LX/ipfs.draft3.pdf
+  'Video: Decentralizing the Web with the InterPlanetary File System (Epicenter Podcast)': https://www.youtube.com/watch?v=erB7i6Uc4DM
+  "Article: It's time for the distributed web — September 2015 (Neocities)": https://blog.neocities.org/blog/2015/09/08/its-time-for-the-distributed-web.html
 ---
 
 # History of the IPFS project
 
-> This content is still preparing for liftoff.
+<ContentStatus />

--- a/docs/project/history.md
+++ b/docs/project/history.md
@@ -1,7 +1,7 @@
 ---
 title: History
 sidebarDepth: 0
-issueNum: https://github.com/ipfs/website/issues/352
+issueUrl: https://github.com/ipfs/website/issues/352
 related:
   'Video: Juan Benet explains the IPFS alpha': https://www.youtube.com/watch?v=skMTdSEaCtA
   'IPFS draft whitepaper': https://ipfs.io/ipfs/QmR7GSQM93Cx5eAg6a6yRzNde1FQv7uL6X1o4k7zrJa3LX/ipfs.draft3.pdf


### PR DESCRIPTION
- Adds related links and associated GitHub issues to stub pages
- Pulls the preface content for issueNum in ContentStatus.vue so we can use full links there

This is one of two remaining pieces to close https://github.com/ipfs/docs/issues/342. The other is to remove "help us improve" link in the footer.