### PR TITLE
Removed .vuepress/nav/en.js 

### DIFF
--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -1,0 +1,1 @@
+module.exports = [{}]

--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -1,6 +1,0 @@
-module.exports = [
-  {
-    text: 'Suggest a Feature',
-    link: 'https://ipfs.canny.io/docs-features'
-  }
-]


### PR DESCRIPTION
Removed .vuepress/nav/en.js since the only thing added to header nav was the Canny link.

Closes https://github.com/ipfs/docs/issues/406