### PR TITLE
Unlinks words and adjusts padding on two bottom-of-pg

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -41,7 +41,7 @@ module.exports = {
         label: 'English',
         selectText: 'Languages',
         ariaLabel: 'Select language',
-        editLinkText: 'Edit this page on GitHub',
+        editLinkText: 'Edit this page',
         lastUpdated: 'Last Updated',
         serviceWorker: {
           updatePopup: {

--- a/docs/.vuepress/theme/components/EditOrIssue.vue
+++ b/docs/.vuepress/theme/components/EditOrIssue.vue
@@ -5,7 +5,7 @@
         editLinkText
       }}</a>
       <span v-if="$site.themeConfig.feedbackWidget.docsRepoIssue">
-        or
+        on GitHub or
         <a :href="openIssueLink" target="_blank" rel="noopener noreferrer"
           >open an issue</a
         >

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -55,6 +55,7 @@ export default {
 
 .content-footer {
   padding-top: 0;
+  max-width: $contentWidth;
 }
 
 .page-edit {

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -67,7 +67,7 @@ export default {
   padding: 0 2rem;
 }
 
-@media (min-width: $MQNarrow) {
+@media (min-width: $MQMobile) {
   .content-footer {
     padding: 0 2.5rem;
     padding-top: 0;

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -68,7 +68,7 @@ export default {
 
 @media (min-width: $MQNarrow) {
   .content-footer {
-    padding: 0 2rem;
+    padding: 0 2.5rem;
     padding-top: 0;
   }
 
@@ -78,7 +78,7 @@ export default {
   }
 
   .page-edit {
-    padding: 2rem 0;
+    padding: 2.5rem 0;
   }
 
   section {


### PR DESCRIPTION
- Unlinks "on GitHub" in the feedback tool, which serves to visually separate the two links in this widget, so users can more easily distinguish them at a glance:
![image](https://user-images.githubusercontent.com/9259185/70940954-0b0aa000-2011-11ea-808d-ace1003837fe.png)

- Adds padding to the left side of the feedback tool and the legacy callout, in order to align them with the page content in desktop view:
![image](https://user-images.githubusercontent.com/9259185/70941133-6b99dd00-2011-11ea-9b4b-e6a129329a15.png)

@cwaring if you have time to further adjust (or ideally, 🍐code with me), these additional tweaks would improve the layout on the legacy callout. If not, we can merge and address later …
- [x] Reduce the width of the green container, so that it right aligns with the page content. (Ideally the green would only blow out to the full width on mobile.)
- [x] Narrow the two columns accordingly (so "Give general feedback" and "Become a tester" shift leftward)
- [x] Add left padding to legacy callout on tablet view, as well

thx!