### PR TITLE
feat: sitewide metadata and seo

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -344,7 +344,32 @@ module.exports = {
             : ($site.themeConfig.domain || '') + $site.themeConfig.defaultImage,
         publishedAt: $page =>
           $page.frontmatter.date && new Date($page.frontmatter.date),
-        modifiedAt: $page => $page.lastUpdated && new Date($page.lastUpdated)
+        modifiedAt: $page => $page.lastUpdated && new Date($page.lastUpdated),
+        customMeta: (add, context) => {
+          const {
+            $site, // Site configs provided by Vuepress
+            $page, // Page configs provided by Vuepress
+
+            // All the computed options from above:
+            siteTitle,
+            title,
+            description,
+            author,
+            tags,
+            twitterCard,
+            type,
+            url,
+            image,
+            publishedAt,
+            modifiedAt
+          } = context
+
+          add(
+            'twitter:site',
+            ($site.themeConfig.author && $site.themeConfig.author.twitter) || ''
+          )
+          add('image', image)
+        }
       }
     ]
   ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -346,24 +346,7 @@ module.exports = {
           $page.frontmatter.date && new Date($page.frontmatter.date),
         modifiedAt: $page => $page.lastUpdated && new Date($page.lastUpdated),
         customMeta: (add, context) => {
-          const {
-            $site, // Site configs provided by Vuepress
-            $page, // Page configs provided by Vuepress
-
-            // All the computed options from above:
-            siteTitle,
-            title,
-            description,
-            author,
-            tags,
-            twitterCard,
-            type,
-            url,
-            image,
-            publishedAt,
-            modifiedAt
-          } = context
-
+          const { $site, image } = context
           add(
             'twitter:site',
             ($site.themeConfig.author && $site.themeConfig.author.twitter) || ''

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,6 +25,7 @@ module.exports = {
     author: { name: 'IPFS Team', twitter: '@ipfsbot' },
     // edit links
     // repo: 'ipfs/ipfs-docs-v2',
+    domain: 'https://docs-beta.ipfs.io',
     docsRepo: 'ipfs/ipfs-docs-v2',
     docsDir: 'docs',
     docsBranch: 'master',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -328,7 +328,8 @@ module.exports = {
         siteTitle: (_, $site) => $site.title,
         title: $page => $page.title,
         description: $page => $page.frontmatter.description,
-        author: (_, $site) => $site.themeConfig.author,
+        author: (_, $site) =>
+          $page.frontmatter.author || $site.themeConfig.author,
         tags: $page => $page.frontmatter.tags,
         twitterCard: _ => 'summary_large_image',
         type: $page =>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -21,6 +21,8 @@ module.exports = {
   themeConfig: {
     betaTestFormUrl:
       'https://docs.google.com/forms/d/1LVaD1B2uyW6Ff0jfU_iQ5mCeyQcHfyQO6BDD99XAgK0/viewform',
+    defaultImage: '/images/social-card.png',
+    author: { name: 'IPFS Team', twitter: '@ipfsbot' },
     // edit links
     // repo: 'ipfs/ipfs-docs-v2',
     docsRepo: 'ipfs/ipfs-docs-v2',
@@ -317,6 +319,31 @@ module.exports = {
       '@vuepress/google-analytics',
       {
         ga: 'UA-96910779-15'
+      }
+    ],
+    [
+      'vuepress-plugin-seo',
+      {
+        siteTitle: (_, $site) => $site.title,
+        title: $page => $page.title,
+        description: $page => $page.frontmatter.description,
+        author: (_, $site) => $site.themeConfig.author,
+        tags: $page => $page.frontmatter.tags,
+        twitterCard: _ => 'summary_large_image',
+        type: $page =>
+          ['articles', 'posts', 'blog'].some(folder =>
+            $page.regularPath.startsWith('/' + folder)
+          )
+            ? 'article'
+            : 'website',
+        url: (_, $site, path) => ($site.themeConfig.domain || '') + path,
+        image: ($page, $site) =>
+          $page.frontmatter.image
+            ? ($site.themeConfig.domain || '') + $page.frontmatter.image
+            : ($site.themeConfig.domain || '') + $site.themeConfig.defaultImage,
+        publishedAt: $page =>
+          $page.frontmatter.date && new Date($page.frontmatter.date),
+        modifiedAt: $page => $page.lastUpdated && new Date($page.lastUpdated)
       }
     ]
   ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -24,7 +24,7 @@ module.exports = {
     defaultImage: '/images/social-card.png',
     author: { name: 'IPFS Team', twitter: '@ipfsbot' },
     keywords:
-      'IPFS, dweb, protocol, libp2p, ipld, multiformats, bitswap, decentralized web',
+      'IPFS, dweb, protocol, libp2p, ipld, multiformats, bitswap, decentralized web, InterPlanetary File System, dapp, documentation, docs, Protocol Labs',
     // edit links
     // repo: 'ipfs/ipfs-docs-v2',
     domain: 'https://docs-beta.ipfs.io',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -23,6 +23,8 @@ module.exports = {
       'https://docs.google.com/forms/d/1LVaD1B2uyW6Ff0jfU_iQ5mCeyQcHfyQO6BDD99XAgK0/viewform',
     defaultImage: '/images/social-card.png',
     author: { name: 'IPFS Team', twitter: '@ipfsbot' },
+    keywords:
+      'IPFS, dweb, protocol, libp2p, ipld, multiformats, bitswap, decentralized web',
     // edit links
     // repo: 'ipfs/ipfs-docs-v2',
     domain: 'https://docs-beta.ipfs.io',
@@ -325,10 +327,10 @@ module.exports = {
     [
       'vuepress-plugin-seo',
       {
-        siteTitle: (_, $site) => $site.title,
+        siteTitle: ($page, $site) => $site.title,
         title: $page => $page.title,
         description: $page => $page.frontmatter.description,
-        author: (_, $site) =>
+        author: ($page, $site) =>
           $page.frontmatter.author || $site.themeConfig.author,
         tags: $page => $page.frontmatter.tags,
         twitterCard: _ => 'summary_large_image',
@@ -338,7 +340,7 @@ module.exports = {
           )
             ? 'article'
             : 'website',
-        url: (_, $site, path) => ($site.themeConfig.domain || '') + path,
+        url: ($page, $site, path) => ($site.themeConfig.domain || '') + path,
         image: ($page, $site) =>
           $page.frontmatter.image
             ? ($site.themeConfig.domain || '') + $page.frontmatter.image
@@ -353,6 +355,7 @@ module.exports = {
             ($site.themeConfig.author && $site.themeConfig.author.twitter) || ''
           )
           add('image', image)
+          add('keywords', $site.themeConfig.keywords)
         }
       }
     ]

--- a/docs/.vuepress/public/robots.txt
+++ b/docs/.vuepress/public/robots.txt
@@ -1,3 +1,10 @@
 # sorry robot friends, we're not ready for the spotlight yet
 User-agent: *
 Disallow: /
+
+# Certain social media sites are whitelisted to allow crawlers to access page markup when links to /images are shared.
+User-agent: Twitterbot
+Allow: /images
+
+User-agent: facebookexternalhit
+Allow: /images

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 ---
 title: IPFS Documentation
 legacyUrl: https://docs.ipfs.io/
+description: The home page for developer documentation for IPFS, the InterPlanetary File System.
 ---
 
 # IPFS Documentation

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,6 +1,7 @@
 ---
 title: Community
 legacyUrl: https://docs.ipfs.io/community/
+description: Become part of the IPFS community! Learn how here.
 ---
 
 # Community

--- a/docs/community/irc.md
+++ b/docs/community/irc.md
@@ -1,6 +1,7 @@
 ---
 title: IRC
 legacyUrl: https://docs.ipfs.io/community/irc/
+description: How to connect with the IPFS community using Internet Relay Chat (IRC).
 ---
 
 # Internet Relay Chat (IRC)

--- a/docs/community/social-media.md
+++ b/docs/community/social-media.md
@@ -2,6 +2,7 @@
 title: Social media
 sidebarDepth: 0
 legacyUrl: https://docs.ipfs.io/community/
+description: Learn where to find IPFS on your favorite social media platform.
 ---
 
 # Social media

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,6 +1,7 @@
 ---
 title: Concepts
 legacyUrl: https://docs.ipfs.io/guides/concepts/
+description: Get started on understanding the key ingredients in the decentralized web, and how IPFS works.
 ---
 
 # IPFS concepts

--- a/docs/concepts/bitswap.md
+++ b/docs/concepts/bitswap.md
@@ -2,6 +2,7 @@
 title: Bitswap
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/docs/issues/85
+description: Learn about Bitswap and how it plays into the overall architecture of IPFS, the InterPlanetary File System.
 related:
   'Article: Swapping bits and distributing hashes on the decentralized web (Textile)': https://medium.com/textileio/swapping-bits-and-distributing-hashes-on-the-decentralized-web-5da98a3507
   'GitHub repo: Go Bitswap implementation': https://github.com/ipfs/go-bitswap

--- a/docs/concepts/content-addressing.md
+++ b/docs/concepts/content-addressing.md
@@ -1,6 +1,7 @@
 ---
 title: Content addressing
 legacyUrl: https://docs.ipfs.io/guides/concepts/cid/
+description: Learn about how content addressing works and how content identifiers, or CIDs, play a crucial role in IPFS.
 ---
 
 # Content addressing and CIDs

--- a/docs/concepts/dht.md
+++ b/docs/concepts/dht.md
@@ -1,6 +1,7 @@
 ---
 title: Distributed Hash Tables (DHTs)
 legacyUrl: https://docs.ipfs.io/guides/concepts/dht/
+description: Learn about how distributed hash tables (DHTs) play a part in the overall lifecycle of IPFS, the InterPlanetary File System.
 ---
 
 # Distributed Hash Tables (DHTs)

--- a/docs/concepts/dnslink.md
+++ b/docs/concepts/dnslink.md
@@ -1,6 +1,7 @@
 ---
 title: DNSLink
 legacyUrl: https://docs.ipfs.io/guides/concepts/dnslink/
+description: Learn how DNSLink works in conjunction with IPFS to map domain names to IPFS content.
 ---
 
 # DNSLink

--- a/docs/concepts/faq.md
+++ b/docs/concepts/faq.md
@@ -1,6 +1,7 @@
 ---
 title: FAQ
 legacyUrl: https://docs.ipfs.io/introduction/faq/
+description: Explore frequently asked questions about IPFS, the InterPlanetary File System.
 ---
 
 # Frequently asked questions

--- a/docs/concepts/file-systems.md
+++ b/docs/concepts/file-systems.md
@@ -1,6 +1,7 @@
 ---
 title: File systems
 legacyUrl: https://docs.ipfs.io/guides/concepts/mfs/
+description: Learn about file systems in IPFS and why working with files in IPFS can be a little different than you may be used to.
 ---
 
 # File systems and IPFS

--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -2,6 +2,7 @@
 title: Glossary
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/docs/issues/56
+description: A glossary guide to key terminology for IPFS, the InterPlanetary File System.
 related:
   'Guide to libp2p terminology': https://docs.libp2p.io/reference/glossary/
   'Article: The Decentralized Web Explained in Words You Can Understand (Breaker)': https://breakermag.com/the-decentralized-web-explained-in-words-you-can-understand/

--- a/docs/concepts/hashing.md
+++ b/docs/concepts/hashing.md
@@ -1,6 +1,7 @@
 ---
 title: Hashing
 legacyUrl: https://docs.ipfs.io/guides/concepts/hashes/
+description: Learn about cryptographic hashes and why they're critical to how IPFS, the InterPlanetary File System, works.
 ---
 
 # Hashing

--- a/docs/concepts/how-ipfs-works.md
+++ b/docs/concepts/how-ipfs-works.md
@@ -1,6 +1,7 @@
 ---
 title: How IPFS works
 legacyUrl: https://docs.ipfs.io/introduction/how-ipfs-works/
+description: Learn how the InterPlanetary File System (IPFS) works and why it's important to the future of the internet.
 ---
 
 # How IPFS works

--- a/docs/concepts/immutability.md
+++ b/docs/concepts/immutability.md
@@ -2,6 +2,7 @@
 title: Immutability
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/docs/issues/386
+description: Learn about the concept of data immutability and how it's critical to how IPFS works.
 related:
   'IPFS Docs: Content addressing and CIDs': /concepts/content-addressing/
   'Video: How IPFS deals with files (IPFS Camp 2019)': https://www.youtube.com/watch?v=Z5zNPwMDYGg

--- a/docs/concepts/ipfs-gateway.md
+++ b/docs/concepts/ipfs-gateway.md
@@ -2,6 +2,7 @@
 title: IPFS Gateway
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/docs/issues/93
+description: Learn why gateways are an important part of using IPFS in conjunction with the legacy web.
 related:
   'IPFS Docs: Address IPFS on the Web': /how-to/address-ipfs-on-web/
   'IPFS public gateway checker': https://ipfs.github.io/public-gateway-checker/

--- a/docs/concepts/ipld.md
+++ b/docs/concepts/ipld.md
@@ -2,6 +2,7 @@
 title: IPLD
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/docs/issues/86
+description: Learn about the InterPlanetary Linked Data (IPLD) model and how it forms an important ingredient in IPFS.
 related:
   'IPLD home page': https://ipld.io/
   'IPLD CID explorer': https://explore.ipld.io/#/explore/QmY7Yh4UquoXHLPFo2XbhXkhBvFoPwmQUSa92pxnxjQuPU

--- a/docs/concepts/ipns.md
+++ b/docs/concepts/ipns.md
@@ -1,6 +1,7 @@
 ---
 title: IPNS
 legacyUrl: https://docs.ipfs.io/guides/concepts/ipns/
+description: Learn about the InterPlanetary Name System (IPNS) and how it can be used in conjunction with IPFS.
 ---
 
 # InterPlanetary Name System (IPNS)

--- a/docs/concepts/libp2p.md
+++ b/docs/concepts/libp2p.md
@@ -2,6 +2,7 @@
 title: libp2p
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/docs/issues/388
+description: Learn about the libp2p protocol and why it's an important ingredient in how IPFS works.
 related:
   'What is libp2p?': https://docs.libp2p.io/introduction/what-is-libp2p/
   'Foundational libp2p concepts': https://docs.libp2p.io/concepts/

--- a/docs/concepts/merkle-dag.md
+++ b/docs/concepts/merkle-dag.md
@@ -1,6 +1,7 @@
 ---
 title: Merkle DAGs
 legacyUrl: https://docs.ipfs.io/guides/concepts/merkle-dag/
+description: Learn about Merkle Distributed Acyclic Graphs (DAGs) and why they're important to IPFS.
 ---
 
 # Merkle Distributed Acyclic Graphs (DAGs)

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -1,6 +1,7 @@
 ---
 title: Persistence
 legacyUrl: https://docs.ipfs.io/guides/concepts/pinning/
+description: Learn about how IPFS treats persistence and permanence on the web, and how pinning can help keep data from being discarded.
 ---
 
 # Persistence, permanence and pinning

--- a/docs/concepts/usage-ideas-examples.md
+++ b/docs/concepts/usage-ideas-examples.md
@@ -2,6 +2,7 @@
 title: Usage ideas & examples
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/docs/issues/387
+description: Explore some helpful use cases, ideas, and examples for IPFS, the InterPlanetary File System.
 related:
   'Awesome IPFS: Showcase of projects and tools built on IPFS': https://awesome.ipfs.io/
   'IPFS Forums: Use cases and applications': https://discuss.ipfs.io/c/ecosystem/applications-of-ipfs

--- a/docs/concepts/what-is-ipfs.md
+++ b/docs/concepts/what-is-ipfs.md
@@ -1,6 +1,7 @@
 ---
 title: What is IPFS?
 legacyUrl: https://docs.ipfs.io/introduction/overview/
+description: Learn about IPFS, the InterPlanetary File System, how it works, and why it's important to the future of the internet.
 ---
 
 # What is IPFS?

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -1,6 +1,7 @@
 ---
 title: How-tos
 legacyUrl: https://docs.ipfs.io/guides/examples/
+description: Hands-on guides to using and developing with IPFS to build decentralized web apps and services.
 ---
 
 # IPFS how-tos and tutorials

--- a/docs/how-to/address-ipfs-on-web.md
+++ b/docs/how-to/address-ipfs-on-web.md
@@ -1,6 +1,7 @@
 ---
 title: Address IPFS on the Web
 legacyUrl: https://docs.ipfs.io/guides/guides/addressing/
+description: Hands-on guides to using and developing with IPFS to build decentralized web apps and services.
 ---
 
 # Address IPFS on the Web
@@ -8,13 +9,14 @@ legacyUrl: https://docs.ipfs.io/guides/guides/addressing/
 This document is a guide to how to address IPFS content paths on the web.
 
 ## Dweb addressing in brief
+
 - In IPFS, addresses (for content) are path-like; they are components separated by slashes.
 - The first component is the protocol, which tells you how to interpret everything after it.
 - Content referenced by a hash might have named links. (For example, a Git commit has a link named `parent`, which is really just a pointer to the hash of another Git commit.) Everything after the CID in an IPFS address are those named links.
 - Since these addresses aren’t URLs, using them in a web browser requires reformatting them slightly:
-    - Through an HTTP gateway, as `http://<gateway host>/<IFPS address>`
-    - Through the gateway subdomain (more secure, harder to set up): `http://<cid>.ipfs.<gateway host>/<path>`, so the protocol and CID are subdomains.
-    - Through custom URL protocols like `ipfs://<CID>/<path>`, `ipns://<peer ID>/<path>`, and `dweb://<IFPS address>`
+  - Through an HTTP gateway, as `http://<gateway host>/<IFPS address>`
+  - Through the gateway subdomain (more secure, harder to set up): `http://<cid>.ipfs.<gateway host>/<path>`, so the protocol and CID are subdomains.
+  - Through custom URL protocols like `ipfs://<CID>/<path>`, `ipns://<peer ID>/<path>`, and `dweb://<IFPS address>`
 
 ## HTTP gateways
 

--- a/docs/how-to/browser-tools-frameworks.md
+++ b/docs/how-to/browser-tools-frameworks.md
@@ -1,5 +1,6 @@
 ---
 title: Browser Tools and Frameworks
+description: Information on how to use IPFS in combination with your favorite frameworks or browser implementation tools.
 ---
 
 # Browser Tools and Frameworks

--- a/docs/how-to/command-line-quick-start.md
+++ b/docs/how-to/command-line-quick-start.md
@@ -1,6 +1,7 @@
 ---
 title: Command-line quick start
 legacyUrl: https://docs.ipfs.io/introduction/usage/
+description: Quick-start guide for installing and getting started with IPFS from the command line.
 ---
 
 # Command-line quick start

--- a/docs/how-to/configure-node.md
+++ b/docs/how-to/configure-node.md
@@ -1,6 +1,7 @@
 ---
 title: Configure a node
 legacyUrl: https://docs.ipfs.io/guides/examples/config/
+description: Learn how to configure a node in IPFS, the InterPlanetary File System.
 ---
 
 # Configure a node

--- a/docs/how-to/host-git-style-repo.md
+++ b/docs/how-to/host-git-style-repo.md
@@ -1,6 +1,7 @@
 ---
 title: Host a Git-style repo
 legacyUrl: https://docs.ipfs.io/guides/examples/git/
+description: Learn how to serve a static Git repository worldwide using IPFS, the InterPlanetary File System.
 ---
 
 # Host a Git-style repo

--- a/docs/how-to/host-single-page-site.md
+++ b/docs/how-to/host-single-page-site.md
@@ -1,6 +1,7 @@
 ---
 title: Host a single-page site
 legacyUrl: https://docs.ipfs.io/guides/examples/websites/
+description: Learn how to host a simple single-page website on the decentralized web using IPFS.
 ---
 
 # Host a single-page website

--- a/docs/how-to/make-service.md
+++ b/docs/how-to/make-service.md
@@ -1,5 +1,6 @@
 ---
 title: Make a service
+description: Learn how to build an easy demo service on IPFS.
 ---
 
 # Make a service

--- a/docs/how-to/modify-bootstrap-list.md
+++ b/docs/how-to/modify-bootstrap-list.md
@@ -1,6 +1,7 @@
 ---
 title: Modify the bootstrap list
 legacyUrl: https://docs.ipfs.io/guides/examples/bootstrap/
+description: Learn how to modify the IPFS bootstrap peers list to create a personal IPFS network.
 ---
 
 # Modify the bootstrap peers list

--- a/docs/how-to/observe-peers.md
+++ b/docs/how-to/observe-peers.md
@@ -1,6 +1,7 @@
 ---
 title: Observe peers
 legacyUrl: https://docs.ipfs.io/guides/examples/network/
+description: Learn the built-in IPFS commands that help you observe peers on the network.
 ---
 
 # Observe peers

--- a/docs/how-to/pin-files.md
+++ b/docs/how-to/pin-files.md
@@ -1,6 +1,7 @@
 ---
 title: Pin files
 legacyUrl: https://docs.ipfs.io/guides/examples/pinning/
+description: Learn how to pin files in IPFS in order to keep your files and other objects local.
 ---
 
 # Pin files using IPFS

--- a/docs/how-to/store-play-videos.md
+++ b/docs/how-to/store-play-videos.md
@@ -1,6 +1,7 @@
 ---
 title: Store & play videos
 legacyUrl: https://docs.ipfs.io/guides/examples/videos/
+description: Learn how to store, play, and work with videos in IPFS, the InterPlanetary File System.
 ---
 
 # Store and play videos

--- a/docs/how-to/take-snapshot.md
+++ b/docs/how-to/take-snapshot.md
@@ -1,6 +1,7 @@
 ---
 title: Take a snapshot
 legacyUrl: https://docs.ipfs.io/guides/examples/snapshots/
+description: Learn about how to take and use snapshots of files in IPFS, the InterPlanetary File System.
 ---
 
 # Take a snapshot

--- a/docs/how-to/work-with-blocks.md
+++ b/docs/how-to/work-with-blocks.md
@@ -1,6 +1,7 @@
 ---
 title: Work with blocks
 legacyUrl: https://docs.ipfs.io/guides/examples/blocks/
+description: Learn how your files are broken down into blocks in IPFS and how to work with them.
 ---
 
 # Work with blocks

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,6 +2,7 @@
 title: Install IPFS
 sidebarDepth: 0
 legacyUrl: https://docs.ipfs.io/introduction/usage/
+description: Get started installing and using IPFS, the InterPlanetary File System, and become part of the decentralized web today.
 ---
 
 # Install IPFS

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,5 +1,6 @@
 ---
 title: The IPFS project
+description: Learn about the history, roadmap, current status and more for IPFS, the InterPlanetary File System.
 ---
 
 # The IPFS project

--- a/docs/project/contribute.md
+++ b/docs/project/contribute.md
@@ -1,6 +1,7 @@
 ---
 title: Contribute to IPFS
 legacyUrl: https://docs.ipfs.io/community/contribute/how-to-help/
+description: Learn about how to contribute to IPFS, the InterPlanetary File System.
 ---
 
 # Contribute to IPFS

--- a/docs/project/history.md
+++ b/docs/project/history.md
@@ -2,6 +2,7 @@
 title: History
 sidebarDepth: 0
 issueUrl: https://github.com/ipfs/website/issues/352
+description: Learn about the history of IPFS, the InterPlanetary File System.
 related:
   'Video: Juan Benet explains the IPFS alpha': https://www.youtube.com/watch?v=skMTdSEaCtA
   'IPFS draft whitepaper': https://ipfs.io/ipfs/QmR7GSQM93Cx5eAg6a6yRzNde1FQv7uL6X1o4k7zrJa3LX/ipfs.draft3.pdf

--- a/docs/project/related-projects.md
+++ b/docs/project/related-projects.md
@@ -1,5 +1,6 @@
 ---
 title: Related projects
+description: Learn about the modular projects that help make up IPFS, the InterPlanetary File System.
 ---
 
 # Related projects

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,6 +1,7 @@
 ---
 title: API & CLI
 legacyUrl: https://docs.ipfs.io/reference/api/
+description: API and CLI reference materials for IPFS, the InterPlanetary File System.
 ---
 
 # API & CLI reference

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,7 @@
 ---
 title: CLI commands
 legacyUrl: https://docs.ipfs.io/reference/api/cli/
+description: Command-line interace (CLI) reference materials for IPFS, the InterPlanetary File System.
 ---
 
 # Command-line interface (CLI) reference

--- a/docs/reference/go/api.md
+++ b/docs/reference/go/api.md
@@ -1,6 +1,7 @@
 ---
 title: go-ipfs API
 legacyUrl: https://docs.ipfs.io/reference/go/overview/
+description: Developer resources for working in Go with IPFS, the InterPlanetary File System.
 ---
 
 # API resources for go-ipfs

--- a/docs/reference/http/api.md
+++ b/docs/reference/http/api.md
@@ -1,6 +1,7 @@
 ---
 title: HTTP API
 legacyUrl: https://docs.ipfs.io/reference/api/http/
+description: HTTP API developer reference materials for IPFS, the InterPlanetary File System.
 ---
 
 # HTTP API reference

--- a/docs/reference/js/api.md
+++ b/docs/reference/js/api.md
@@ -1,6 +1,7 @@
 ---
 title: js-ipfs API
 legacyUrl: https://docs.ipfs.io/reference/js/
+description: Developer resources for working in JavaScript with IPFS, the InterPlanetary File System.
 ---
 
 # API resources for js-ipfs

--- a/package-lock.json
+++ b/package-lock.json
@@ -11481,6 +11481,12 @@
         "markdown-it-container": "^2.0.0"
       }
     },
+    "vuepress-plugin-seo": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-seo/-/vuepress-plugin-seo-0.1.2.tgz",
+      "integrity": "sha512-Tv3ihNl3pDX5krqq9r2X9rFKUVR8ssLvcKcu1P4ABP8/b3vC06St/UTe5QucgKzuphlIJkbRSOQ7n7yf6jMCRw==",
+      "dev": true
+    },
     "vuepress-plugin-smooth-scroll": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-smooth-scroll/-/vuepress-plugin-smooth-scroll-0.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prettier": "^1.19.1",
     "stylus-supremacy": "^2.14.0",
     "vuepress": "^1.2.0",
-    "vuepress-plugin-clean-urls": "^1.1.1"
+    "vuepress-plugin-clean-urls": "^1.1.1",
+    "vuepress-plugin-seo": "^0.1.2"
   },
   "prettier": {
     "arrowParens": "avoid",


### PR DESCRIPTION
Now it is as easy as adding a single `description` key to the front matter of a page to add rich meta previews. You can override any individual items on a page by page basis by appending the items to the front matter.

Implements: https://github.com/ipfs/docs/issues/343