### PR TITLE
fix: add canonical link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -364,7 +364,7 @@ module.exports = {
       {
         // add <link rel="canonical" header (https://tools.ietf.org/html/rfc6596)
         // to deduplicate SEO across all copies loaded from various public gateways
-        baseURL: 'https://docs.ipfs.io'
+        baseURL: 'https://docs-beta.ipfs.io'
       }
     ]
   ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -358,6 +358,14 @@ module.exports = {
           add('keywords', $site.themeConfig.keywords)
         }
       }
+    ],
+    [
+      'vuepress-plugin-canonical',
+      {
+        // add <link rel="canonical" header (https://tools.ietf.org/html/rfc6596)
+        // to deduplicate SEO across all copies loaded from various public gateways
+        baseURL: 'https://docs.ipfs.io'
+      }
     ]
   ],
   extraWatchFiles: ['.vuepress/nav/en.js']

--- a/package-lock.json
+++ b/package-lock.json
@@ -4381,8 +4381,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4403,14 +4402,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4425,20 +4422,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4555,8 +4549,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4568,7 +4561,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4583,7 +4575,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4591,14 +4582,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4617,7 +4606,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4698,8 +4686,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4711,7 +4698,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4797,8 +4783,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4834,7 +4819,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4854,7 +4838,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4898,14 +4881,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -11465,6 +11446,12 @@
           }
         }
       }
+    },
+    "vuepress-plugin-canonical": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-canonical/-/vuepress-plugin-canonical-1.0.0.tgz",
+      "integrity": "sha512-R2mcc+bp9VbKBQ3YIbCqUbWcWfmWSp1NIEyNGiLKkrcZmyUF/+0D48BqMCTx61AgJzWPW5DJzB6VkmpjbMIDbA==",
+      "dev": true
     },
     "vuepress-plugin-clean-urls": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "^1.19.1",
     "stylus-supremacy": "^2.14.0",
     "vuepress": "^1.2.0",
+    "vuepress-plugin-canonical": "^1.0.0",
     "vuepress-plugin-clean-urls": "^1.1.1",
     "vuepress-plugin-seo": "^0.1.2"
   },


### PR DESCRIPTION
This PR adds `<link rel="canonical"` header ([rfc6596](https://tools.ietf.org/html/rfc6596), [Wikipedia](https://en.wikipedia.org/wiki/Canonical_link_element)) to deduplicate SEO across all copies loaded from various public IPFS gateways.


Prior Art:
- https://github.com/ipfs/distributed-wikipedia-mirror/issues/65
- https://github.com/vuejs/vuepress/issues/894