### PR TITLE
Fix typo

### DIFF
--- a/docs/concepts/how-ipfs-works.md
+++ b/docs/concepts/how-ipfs-works.md
@@ -42,7 +42,7 @@ The IPFS protocol uses IPLD to get from raw content to an IPFS address. IPFS has
 
 ## Directed acyclic graphs (DAGs)
 
-IPFS and many other distributed systems take advantage of a data structure called [directed acyclic graphs](https://en.wikipedia.org/wiki/Directed_acyclic_graph), or DAGs. Specifically, they use _Merkle DAGs_, which are DAGs where each node has an identifier that is a hash of the node’s contents. Sound familiar? This refers back to the _CID_ concept that we covered in the previous section. Another way to look the this CID-linked-data concept: identifying a data object (like a Merkle DAG node) by the value of its hash is _content addressing_. Check out our [guide to Merkle DAGs](/concepts/merkle-dag/) for a more in-depth treatment of this topic.
+IPFS and many other distributed systems take advantage of a data structure called [directed acyclic graphs](https://en.wikipedia.org/wiki/Directed_acyclic_graph), or DAGs. Specifically, they use _Merkle DAGs_, which are DAGs where each node has an identifier that is a hash of the node’s contents. Sound familiar? This refers back to the _CID_ concept that we covered in the previous section. Another way to look at the CID-linked-data concept: identifying a data object (like a Merkle DAG node) by the value of its hash is _content addressing_. Check out our [guide to Merkle DAGs](/concepts/merkle-dag/) for a more in-depth treatment of this topic.
 
 IPFS uses a Merkle DAG that is optimized for representing directories and files, but you can structure a Merkle DAG in many different ways. For example, Git uses a Merkle DAG that has many versions of your repo inside of it.
 


### PR DESCRIPTION
The diff doesn't show it very clearly but this change removes the word "this" from the following sentence:

> Another way to look the this CID-linked-data concept