### PR TITLE
Add IPFS Primer links

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -76,6 +76,10 @@ module.exports = {
                 children: [
                   '/concepts/what-is-ipfs',
                   '/concepts/how-ipfs-works',
+                   [
+                    'https://dweb-primer.ipfs.io/',
+                    'IPFS primer'
+                  ]
                   '/concepts/usage-ideas-examples',
                   '/concepts/glossary',
                   '/concepts/faq'

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -76,10 +76,7 @@ module.exports = {
                 children: [
                   '/concepts/what-is-ipfs',
                   '/concepts/how-ipfs-works',
-                   [
-                    'https://dweb-primer.ipfs.io/',
-                    'IPFS primer'
-                  ]
+                  ['https://dweb-primer.ipfs.io/', 'IPFS primer'],
                   '/concepts/usage-ideas-examples',
                   '/concepts/glossary',
                   '/concepts/faq'

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -23,6 +23,7 @@ Get the basic concepts of IPFS in one place, including:
 
 - [What is IPFS?](/concepts/what-is-ipfs/)
 - [How IPFS works](/concepts/how-ipfs-works/)
+- [IPFS primer](https://dweb-primer.ipfs.io/)
 - [Usage ideas & examples](/concepts/usage-ideas-examples/)
 - [Glossary](/concepts/glossary/)
 - [FAQ](/concepts/faq/)


### PR DESCRIPTION
Adds a link to the IPFS primer ...
1. in the left-hand nav, in Concepts/IPFS 101
2. to the "IPFS 101" section of https://docs-beta.ipfs.io/concepts/

Note that this isn't perfect, because the IPFS primer itself contains more hands-on tutorials, but it's the most applicable place at present. In the longer term, we need to outsource/bounty-ize the remaining missing content in the IPFS primer, and then integrate that content as a whole either into the docs or ProtosSchool. See https://airtable.com/tbl21O1nXqFA7ADcT/viws9P58CvH333ZAW/recI3I40kyWLHXL6H for where this fits into our prioritized recommendations from the Q1 2020 ecosystem audit.