### PR TITLE
Move content originally in ipfs/ipfs repo to docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -306,14 +306,8 @@ module.exports = {
             path: '/project/',
             children: [
               'project/history',
-              [
-                'https://github.com/ipfs/ipfs/blob/master/REQUIREMENTS.md',
-                'Roadmap'
-              ],
-              [
-                'https://github.com/ipfs/ipfs/blob/master/IMPLEMENTATION_STATUS.md',
-                'Implementation status'
-              ],
+              'project/roadmap,
+              'project/implementation-status',
               ['https://github.com/ipfs/specs', 'Specifications'],
               ['https://github.com/ipfs/research', 'Research'],
               ['https://github.com/ipfs/team-mgmt', 'Team org planning'],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -306,7 +306,7 @@ module.exports = {
             path: '/project/',
             children: [
               'project/history',
-              'project/roadmap,
+              'project/roadmap',
               'project/implementation-status',
               ['https://github.com/ipfs/specs', 'Specifications'],
               ['https://github.com/ipfs/research', 'Research'],

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -13,11 +13,11 @@ Want to know how it all began? Learn the [history of the IPFS project](/project/
 
 ## Roadmap
 
-See the overall roadmap of [IPFS project requirements](https://github.com/ipfs/ipfs/blob/master/REQUIREMENTS.md) from current state to maturity.
+See the overall roadmap of [IPFS project requirements](/project/roadmap) from current state to maturity.
 
 ## Implementation status
 
-Want to know the current state of your favorite IPFS feature? See the [current implementation status](https://github.com/ipfs/ipfs/blob/master/IMPLEMENTATION_STATUS.md) for go-ipfs and js-ipfs, listed by commands and endpoints.
+Want to know the current state of your favorite IPFS feature? See the [current implementation status](/project/implementation-status) for go-ipfs and js-ipfs, listed by commands and endpoints.
 
 ## IPFS specifications
 

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -1,19 +1,15 @@
 ---
-title: IPFS implementation status
+title: Implementation status
 description: See the current status of various aspects of the core IPFS implementations.
 ---
 
 # IPFS implementation status
 
-Legend: :green_apple: Done &nbsp; :lemon: In Progress &nbsp; :tomato: Missing &nbsp; :chestnut: Not planned
-
-# Table of Contents
-
-# API
+### Legend: :green_apple: Done &nbsp; :lemon: In Progress &nbsp; :tomato: Missing &nbsp; :chestnut: Not planned
 
 ## Bitswap
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -26,7 +22,7 @@ Legend: :green_apple: Done &nbsp; :lemon: In Progress &nbsp; :tomato: Missing &n
 | **`ipfs bitswap wantlist`**                  | :green_apple: | :green_apple: |
 |     `peer`                                   | :green_apple: | :green_apple: |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -39,7 +35,7 @@ Legend: :green_apple: Done &nbsp; :lemon: In Progress &nbsp; :tomato: Missing &n
 | **`GET /api/v0/bitswap/wantlist`**           | :green_apple: | :green_apple: |
 |     `peer=`                                  | :green_apple: | :green_apple: |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -47,7 +43,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Block `ipfs block`
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -64,7 +60,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`ipfs block stat`**                        | :green_apple: | :green_apple: |
 |     `key`                                    | :green_apple: | :green_apple: |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -81,7 +77,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`GET /api/v0/block/stat`**                 | :green_apple: | :green_apple: |
 |     `arg=`                                   | :green_apple: | :green_apple: |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -89,7 +85,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Bootstrap
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -101,7 +97,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `arg=`                                   | :green_apple: | :green_apple: |
 |     `all=`                                   | :green_apple: | :green_apple: |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -115,7 +111,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `all=`                                   | :green_apple: | :green_apple: |
 | **`GET /api/v0/bootstrap/rm/all`**           | :green_apple: | :tomato:      |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -123,7 +119,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Config
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -142,7 +138,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`ipfs log ls`**                            | :green_apple: | :chestnut:    |
 | **`ipfs log tail`**                          | :green_apple: | :chestnut:    |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -161,7 +157,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`GET /api/v0/log/ls`**                     | :green_apple: | :chestnut:    |
 | **`GET /api/v0/log/tail`**                   | :green_apple: | :chestnut:    |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -173,19 +169,19 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 - https://github.com/ipfs/js-ipfs-api/pull/534
 - https://github.com/ipfs/go-ipfs/issues/3771#issue-213068794
 
-#### CLI
+### CLI
 
-#### HTTP
+### HTTP
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 --------------------------------------------------------------------------------
 
-## Stats and Diagnostics
+## Stats and diagnostics
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -202,7 +198,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `time`                                   | :green_apple: | :chestnut:    |
 | **`ipfs diag sys`**                          | :green_apple: | :chestnut:    |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -221,7 +217,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `vis`                                    | :green_apple: | :chestnut:    |
 | **`GET /api/v0/sys`**                        | :green_apple: | :chestnut:    |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -229,7 +225,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## DHT
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -255,7 +251,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `peer ID`                                | :green_apple: | :green_apple: |
 |     `verbose=`                               | :green_apple: | :tomato:      |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -281,7 +277,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `arg=`                                   | :green_apple: | :green_apple: |
 |     `verbose=`                               | :green_apple: | :tomato:      |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -289,7 +285,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Files
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -363,7 +359,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `compress`                               | :green_apple: | :tomato:      |
 |     `compression-level`                      | :green_apple: | :tomato:      |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -447,29 +443,29 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `compression-level=8`                    | :green_apple: | :tomato:      |
 |     `compression-level=9`                    | :green_apple: | :tomato:      |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 --------------------------------------------------------------------------------
 
-## File Store (IPFS Pack)
+## File store (IPFS pack)
 
 > **Note:** Implementation in js-ipfs is not planned for now.
 
-#### CLI
+### CLI
 
-#### HTTP
+### HTTP
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 --------------------------------------------------------------------------------
 
-## Key Management
+## Key management
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl        |
 | -------------------------------------------- | :-----------: | :-----------:  |
@@ -487,7 +483,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `name`                                   | :green_apple: | :chestnut:     |
 |     `l=`                                     | :green_apple: | :chestnut:     |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl        |
 | -------------------------------------------- | :-----------: | :-----------:  |
@@ -505,7 +501,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `arg=`                                   | :green_apple: | :chestnut:     |
 |     `l=`                                     | :green_apple: | :chestnut:     |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -513,7 +509,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Miscellaneous
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -534,7 +530,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `ipns-path=`                             | :green_apple: | :chestnut:    |
 | **`ipfs mount`**                             | :green_apple: | :chestnut:    |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -551,7 +547,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `ipns-path=`                             | :green_apple: | :chestnut:    |
 | **`GET /api/v0/mount`**                      | :green_apple: | :chestnut:    |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -561,7 +557,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 > **Note:** Implementation in js-ipfs is blocked until DHT is finished.
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -582,7 +578,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `domain`                                 | :green_apple: | :tomato:      |
 |     `recursive=`                             | :green_apple: | :tomato:      |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -603,7 +599,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `arg=`                                   | :green_apple: | :tomato:      |
 |     `recursive=`                             | :green_apple: | :tomato:      |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -611,7 +607,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Object `ipfs object`
 
-#### CLI
+### CLI
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -649,7 +645,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`GET /api/v0/object/stat`**                | :green_apple: | :green_apple: |
 |     `root`                                   | :green_apple: | :green_apple: |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -687,7 +683,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`GET /api/v0/object/stat`**                | :green_apple: | :green_apple: |
 |     `arg=`                                   | :green_apple: | :green_apple: |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -697,19 +693,19 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 > **This is blocked until there is a formalized `interface-libp2p`**. Currently, js-ipfs exposes libp2p directly while go-ipfs exposes a subset of commands that use libp2p.
 
-#### CLI
+### CLI
 
-#### HTTP
+### HTTP
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 --------------------------------------------------------------------------------
 
-## Pining
+## Pinning
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -736,7 +732,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `recursive`                              | :green_apple: | :tomato:      |
 | **`ipfs refs local`**                        | :green_apple: | :tomato:      |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -762,7 +758,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `recursive=`                             | :green_apple: | :tomato:      |
 | **`GET /api/v0//refs/local`**                | :green_apple: | :tomato:      |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -770,7 +766,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## PubSub
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -784,7 +780,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `topic`                                  | :green_apple: | :green_apple: |
 |     `discover`                               | :green_apple: | :tomato:      |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -798,7 +794,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `arg=`                                   | :green_apple: | :green_apple: |
 |     `discover=`                              | :green_apple: | :green_apple: |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -806,7 +802,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Repo
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -816,7 +812,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`ipfs repo verify`**                       | :green_apple: | :chestnut:    |
 | **`ipfs repo version`**                      | :green_apple: | :green_apple: |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -826,7 +822,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 | **`GET /api/v0/repo/verify`**                | :green_apple: | :chestnut:    |
 | **`GET /api/v0/repo/version`**               | :green_apple: | :green_apple: |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
@@ -834,7 +830,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 ## Swarm
 
-#### CLI
+### CLI
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -856,7 +852,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `latency=`                               | :green_apple: | :tomato:      |
 |     `streams=`                               | :green_apple: | :tomato:      |
 
-#### HTTP
+### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
@@ -878,7 +874,7 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 |     `latency=`                               | :green_apple: | :tomato:      |
 |     `streams=`                               | :green_apple: | :tomato:      |
 
-#### Core
+### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -39,7 +39,6 @@ description: See the current status of various aspects of the core IPFS implemen
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Block `ipfs block`
 
@@ -81,8 +80,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
-
 ## Bootstrap
 
 ### CLI
@@ -115,7 +112,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Config
 
@@ -161,7 +157,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## DAG
 
@@ -176,8 +171,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 ### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
-
---------------------------------------------------------------------------------
 
 ## Stats and diagnostics
 
@@ -220,8 +213,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 ### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
-
---------------------------------------------------------------------------------
 
 ## DHT
 
@@ -281,7 +272,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Files
 
@@ -447,8 +437,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
-
 ## File store (IPFS pack)
 
 > **Note:** Implementation in js-ipfs is not planned for now.
@@ -461,7 +449,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Key management
 
@@ -505,7 +492,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Miscellaneous
 
@@ -551,7 +537,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Naming
 
@@ -603,7 +588,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Object `ipfs object`
 
@@ -687,7 +671,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## p2p (libp2p exposed API)
 
@@ -701,7 +684,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Pinning
 
@@ -762,7 +744,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## PubSub
 
@@ -798,7 +779,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Repo
 
@@ -826,7 +806,6 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
---------------------------------------------------------------------------------
 
 ## Swarm
 
@@ -877,5 +856,3 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 ### Core
 
 See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
-
---------------------------------------------------------------------------------

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -1,0 +1,885 @@
+---
+title: IPFS implementation status
+description: See the current status of various aspects of the core IPFS implementations.
+---
+
+# IPFS implementation status
+
+Legend: :green_apple: Done &nbsp; :lemon: In Progress &nbsp; :tomato: Missing &nbsp; :chestnut: Not planned
+
+# Table of Contents
+
+# API
+
+## Bitswap
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs ledger`**                            | :green_apple: | :lemon:       |
+|     `peer`                                   | :green_apple: | :lemon:       |
+| **`ipfs reprovide`**                         | :green_apple: | :tomato:      |
+| **`ipfs bitswap stat`**                      | :green_apple: | :green_apple: |
+| **`ipfs bitswap unwant`**                    | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+| **`ipfs bitswap wantlist`**                  | :green_apple: | :green_apple: |
+|     `peer`                                   | :green_apple: | :green_apple: |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/bitswap/ledger`**             | :green_apple: | :lemon:       |
+|     `arg=`                                   | :green_apple: | :lemon:       |
+| **`GET /api/v0/bitswap/reprovide`**          | :green_apple: | :tomato:      |
+| **`GET /api/v0/bitswap/stat`**               | :green_apple: | :green_apple: |
+| **`GET /api/v0/bitswap/unwant`**             | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/bitswap/wantlist`**           | :green_apple: | :green_apple: |
+|     `peer=`                                  | :green_apple: | :green_apple: |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Block `ipfs block`
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs block get`**                         | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+| **`ipfs block put`**                         | :green_apple: | :green_apple: |
+|     `data`                                   | :green_apple: | :green_apple: |
+|     `format`                                 | :green_apple: | :green_apple: |
+|     `mhtype`                                 | :green_apple: | :green_apple: |
+|     `mhlen`                                  | :green_apple: | :green_apple: |
+| **`ipfs block rm`**                          | :green_apple: | :lemon:       |
+|     `hash`                                   | :green_apple: | :lemon:       |
+|     `force`                                  | :green_apple: | :lemon:       |
+| **`ipfs block stat`**                        | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/block/get`**                  | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`POST /api/v0/block/put`**                 | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `format=`                                | :green_apple: | :green_apple: |
+|     `mhtype=`                                | :green_apple: | :green_apple: |
+|     `mhlen=`                                 | :green_apple: | :green_apple: |
+| **`GET /api/v0/block/rm`**                   | :green_apple: | :lemon:       |
+|     `arg=`                                   | :green_apple: | :lemon:       |
+|     `force=`                                 | :green_apple: | :lemon:       |
+| **`GET /api/v0/block/stat`**                 | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Bootstrap
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs bootstrap add`**                     | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `default=`                               | :green_apple: | :green_apple: |
+| **`ipfs bootstrap list`**                    | :green_apple: | :green_apple: |
+| **`ipfs bootstrap rm`**                      | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `all=`                                   | :green_apple: | :green_apple: |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/bootstrap/add`**              | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `default=`                               | :green_apple: | :green_apple: |
+| **`GET /api/v0/bootstrap/add/default`**      | :green_apple: | :tomato:      |
+| **`GET /api/v0/bootstrap/list`**             | :green_apple: | :green_apple: |
+| **`GET /api/v0/bootstrap/rm`**               | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `all=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/bootstrap/rm/all`**           | :green_apple: | :tomato:      |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Config
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs config edit`**                       | :green_apple: | :chestnut:    |
+| **`ipfs config`**                            | :green_apple: | :chestnut:    |
+|     `key`                                    | :green_apple: | :green_apple: |
+|     `value`                                  | :green_apple: | :green_apple: |
+|     `bool=`                                  | :green_apple: | :green_apple: |
+|     `json=`                                  | :green_apple: | :green_apple: |
+| **`ipfs config replace`**                    | :green_apple: | :green_apple: |
+|     `file`                                   | :green_apple: | :green_apple: |
+| **`ipfs config show`**                       | :green_apple: | :green_apple: |
+| **`ipfs log level`**                         | :green_apple: | :chestnut:    |
+|     `subsystem`                              | :green_apple: | :chestnut:    |
+|     `level`                                  | :green_apple: | :chestnut:    |
+| **`ipfs log ls`**                            | :green_apple: | :chestnut:    |
+| **`ipfs log tail`**                          | :green_apple: | :chestnut:    |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/config/edit`**                | :green_apple: | :chestnut:    |
+| **`POST /api/v0/config`**                    | :green_apple: | :chestnut:    |
+|     `arg1=`                                  | :green_apple: | :green_apple: |
+|     `arg2=`                                  | :green_apple: | :green_apple: |
+|     `bool=`                                  | :green_apple: | :green_apple: |
+|     `json=`                                  | :green_apple: | :green_apple: |
+| **`POST /api/v0/config/replace`**            | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/config/show`**                | :green_apple: | :green_apple: |
+| **`POST /api/v0/log/level`**                 | :green_apple: | :chestnut:    |
+|     `arg1=`                                  | :green_apple: | :chestnut:    |
+|     `arg2=`                                  | :green_apple: | :chestnut:    |
+| **`GET /api/v0/log/ls`**                     | :green_apple: | :chestnut:    |
+| **`GET /api/v0/log/tail`**                   | :green_apple: | :chestnut:    |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## DAG
+
+> **Blocked until the following are resolved:**
+- https://github.com/ipfs/js-ipfs-api/pull/534
+- https://github.com/ipfs/go-ipfs/issues/3771#issue-213068794
+
+#### CLI
+
+#### HTTP
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Stats and Diagnostics
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs stats bitswap`**                     | :green_apple: | :tomato:      |
+| **`ipfs stats bw`**                          | :green_apple: | :tomato:      |
+|     `peer`                                   | :green_apple: | :tomato:      |
+|     `proto`                                  | :green_apple: | :tomato:      |
+|     `poll`                                   | :green_apple: | :tomato:      |
+|     `interval `                              | :green_apple: | :tomato:      |
+| **`ipfs stats repo`**                        | :green_apple: | :tomato:      |
+| **`ipfs diag cmds`**                         | :green_apple: | :chestnut:    |
+| **`ipfs diag cmds clear`**                   | :green_apple: | :chestnut:    |
+| **`ipfs diag cmds set-time`**                | :green_apple: | :chestnut:    |
+|     `time`                                   | :green_apple: | :chestnut:    |
+| **`ipfs diag sys`**                          | :green_apple: | :chestnut:    |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/stats/bitswap`**              | :green_apple: | :tomato:      |
+| **`POST /api/v0/stats/bw`**                  | :green_apple: | :tomato:      |
+|     `peer=`                                  | :green_apple: | :tomato:      |
+|     `proto=`                                 | :green_apple: | :tomato:      |
+|     `poll=`                                  | :green_apple: | :tomato:      |
+|     `interval=`                              | :green_apple: | :tomato:      |
+| **`GET /api/v0/stats/repo`**                 | :green_apple: | :tomato:      |
+| **`GET /api/v0/diag/cmds`**                  | :green_apple: | :chestnut:    |
+| **`GET /api/v0/diag/cmds/clear`**            | :green_apple: | :chestnut:    |
+| **`GET /api/v0/diag/cmds/set-time`**         | :green_apple: | :chestnut:    |
+|     `arg=`                                   | :green_apple: | :chestnut:    |
+| **`GET /api/v0/net`**                        | :green_apple: | :chestnut:    |
+|     `vis`                                    | :green_apple: | :chestnut:    |
+| **`GET /api/v0/sys`**                        | :green_apple: | :chestnut:    |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## DHT
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs dht findpeer`**                      | :green_apple: | :green_apple: |
+|     `peer ID`                                | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`ipfs dht findprovs`**                     | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+|     `num-providers=`                         | :green_apple: | :green_apple: |
+| **`ipfs dht get`**                           | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`ipfs dht provide`**                       | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`ipfs dht put`**                           | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+|     `value`                                  | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`ipfs dht query`**                         | :green_apple: | :tomato:      |
+|     `peer ID`                                | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/dht/findpeer`**               | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`GET /api/v0/dht/findprovs`**              | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+|     `num-providers=`                         | :green_apple: | :green_apple: |
+| **`GET /api/v0/dht/get`**                    | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`GET /api/v0/dht/provide`**                | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`GET /api/v0/dht/put`**                    | :green_apple: | :green_apple: |
+|     `arg1=`                                  | :green_apple: | :green_apple: |
+|     `arg2=`                                  | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`GET /api/v0/dht/query`**                  | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Files
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs add`**                               | :green_apple: | :lemon:       |
+|     `file`                                   | :green_apple: | :green_apple: |
+|     `recursive`                              | :green_apple: | :green_apple: |
+|     `quiet`                                  | :green_apple: | :green_apple: |
+|     `quieter`                                | :green_apple: | :green_apple: |
+|     `silent`                                 | :green_apple: | :green_apple: |
+|     `progress`                               | :green_apple: | :green_apple: |
+|     `trickle`                                | :green_apple: | :green_apple: |
+|     `only-hash`                              | :green_apple: | :green_apple: |
+|     `wrap-with-directory`                    | :green_apple: | :green_apple: |
+|     `hidden`                                 | :green_apple: | :tomato:      |
+|     `chunker`                                | :green_apple: | :tomato:      |
+|     `pin`                                    | :green_apple: | :lemon:       |
+|     `raw-leaves`                             | :green_apple: | :tomato:      |
+|     `nocopy`                                 | :green_apple: | :tomato:      |
+|     `fscache`                                | :green_apple: | :tomato:      |
+|     `cid-version`                            | :green_apple: | :tomato:      |
+|     `hash`                                   | :green_apple: | :tomato:      |
+| **`ipfs cat`**                               | :green_apple: | :green_apple: |
+|     `arg`                                    | :green_apple: | :green_apple: |
+| **`ipfs ls`**                                | :green_apple: | :lemon:       |
+|     `arg`                                    | :green_apple: | :lemon:       |
+|     `headers`                                | :green_apple: | :lemon:       |
+|     `resolve-type`                           | :green_apple: | :lemon:       |
+| **`ipfs file ls`**                           | :green_apple: | :chestnut:    |
+|     `path`                                   | :green_apple: | :chestnut:    |
+| **`ipfs files cp`**                          | :green_apple: | :tomato:      |
+|     `src`                                    | :green_apple: | :tomato:      |
+|     `dst`                                    | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs files flush`**                       | :green_apple: | :tomato:      |
+|     `path`                                   | :green_apple: | :tomato:      |
+| **`ipfs files ls`**                          | :green_apple: | :tomato:      |
+|     `path`                                   | :green_apple: | :tomato:      |
+|     `level`                                  | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs files mkdir`**                       | :green_apple: | :tomato:      |
+|     `path`                                   | :green_apple: | :tomato:      |
+|     `parents`                                | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs files mv`**                          | :green_apple: | :tomato:      |
+|     `src`                                    | :green_apple: | :tomato:      |
+|     `dst`                                    | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs files read`**                        | :green_apple: | :tomato:      |
+|     `path`                                   | :green_apple: | :tomato:      |
+|     `offset`                                 | :green_apple: | :tomato:      |
+|     `count`                                  | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs files rm`**                          | :green_apple: | :tomato:      |
+|     `path`                                   | :green_apple: | :tomato:      |
+|     `recursive`                              | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs files stat`**                        | :green_apple: | :tomato:      |
+|     `path`                                   | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs files write`**                       | :green_apple: | :tomato:      |
+|     `path`                                   | :green_apple: | :tomato:      |
+|     `data`                                   | :green_apple: | :tomato:      |
+|     `offset`                                 | :green_apple: | :tomato:      |
+|     `create`                                 | :green_apple: | :tomato:      |
+|     `truncate`                               | :green_apple: | :tomato:      |
+|     `count`                                  | :green_apple: | :tomato:      |
+|     `flush`                                  | :green_apple: | :tomato:      |
+| **`ipfs get`**                               | :green_apple: | :green_apple: |
+|     `path`                                   | :green_apple: | :green_apple: |
+|     `archive`                                | :green_apple: | :tomato:      |
+|     `compress`                               | :green_apple: | :tomato:      |
+|     `compression-level`                      | :green_apple: | :tomato:      |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`POST /api/v0/add`**                       | :green_apple: | :lemon:       |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `recursive=`                             | :green_apple: | :green_apple: |
+|     `quiet=`                                 | :green_apple: | :tomato:      |
+|     `quieter=`                               | :green_apple: | :tomato:      |
+|     `silent=`                                | :green_apple: | :tomato:      |
+|     `progress=`                              | :green_apple: | :green_apple: |
+|     `trickle=`                               | :green_apple: | :green_apple: |
+|     `only-hash=`                             | :green_apple: | :green_apple: |
+|     `wrap-with-directory`                    | :green_apple: | :green_apple: |
+|     `hidden`                                 | :green_apple: | :tomato:      |
+|     `chunker`                                | :green_apple: | :tomato:      |
+|     `pin`                                    | :green_apple: | :lemon:       |
+|     `raw-leaves`                             | :green_apple: | :tomato:      |
+|     `nocopy`                                 | :green_apple: | :tomato:      |
+|     `fscache`                                | :green_apple: | :tomato:      |
+|     `cid-version`                            | :green_apple: | :tomato:      |
+|     `hash`                                   | :green_apple: | :tomato:      |
+| **`GET /api/v0/cat`**                        | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/ls`**                         | :green_apple: | :lemon:       |
+|     `arg=`                                   | :green_apple: | :lemon:       |
+|     `headers=`                               | :green_apple: | :lemon:       |
+|     `resolve-type=`                          | :green_apple: | :lemon:       |
+| **`GET /api/v0/file/ls`**                    | :green_apple: | :chestnut:    |
+|     `arg=`                                   | :green_apple: | :chestnut:    |
+| **`GET /api/v0/files/cp`**                   | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `arg2=`                                  | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`GET /api/v0/files/flush`**                | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+| **`GET /api/v0/files/ls`**                   | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `l=`                                     | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`GET /api/v0/files/mkdir`**                | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `parents=,p=`                            | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`GET /api/v0/files/mv`**                   | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `arg2=`                                  | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`GET /api/v0/files/read`**                 | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `offset=,o=`                             | :green_apple: | :tomato:      |
+|     `count=,n=`                              | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`POST /api/v0/files/rm`**                  | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `recursive=,r=`                          | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`GET /api/v0/files/stat`**                 | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`POST /api/v0/files/write`**               | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `arg2=`                                  | :green_apple: | :tomato:      |
+|     `offset=,o=`                             | :green_apple: | :tomato:      |
+|     `create=,e=`                             | :green_apple: | :tomato:      |
+|     `truncate=,t=`                           | :green_apple: | :tomato:      |
+|     `count=,n=`                              | :green_apple: | :tomato:      |
+|     `flush=,f=`                              | :green_apple: | :tomato:      |
+| **`POST /api/v0/get`**                       | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `archive=`                               | :green_apple: | :tomato:      |
+|     `compress=`                              | :green_apple: | :tomato:      |
+|     `compression-level=-1`                   | :green_apple: | :tomato:      |
+|     `compression-level=0`                    | :green_apple: | :tomato:      |
+|     `compression-level=1`                    | :green_apple: | :tomato:      |
+|     `compression-level=2`                    | :green_apple: | :tomato:      |
+|     `compression-level=3`                    | :green_apple: | :tomato:      |
+|     `compression-level=4`                    | :green_apple: | :tomato:      |
+|     `compression-level=5`                    | :green_apple: | :tomato:      |
+|     `compression-level=6`                    | :green_apple: | :tomato:      |
+|     `compression-level=7`                    | :green_apple: | :tomato:      |
+|     `compression-level=8`                    | :green_apple: | :tomato:      |
+|     `compression-level=9`                    | :green_apple: | :tomato:      |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## File Store (IPFS Pack)
+
+> **Note:** Implementation in js-ipfs is not planned for now.
+
+#### CLI
+
+#### HTTP
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Key Management
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl        |
+| -------------------------------------------- | :-----------: | :-----------:  |
+| **`ipfs key gen`**                           | :green_apple: | :chestnut:     |
+|     `name`                                   | :green_apple: | :chestnut:     |
+|     `type=`                                  | :green_apple: | :chestnut:     |
+|     `size=`                                  | :green_apple: | :chestnut:     |
+| **`ipfs key list`**                          | :green_apple: | :chestnut:     |
+|     `l=`                                     | :green_apple: | :chestnut:     |
+| **`ipfs key rename`**                        | :green_apple: | :chestnut:     |
+|     `name`                                   | :green_apple: | :chestnut:     |
+|     `newName`                                | :green_apple: | :chestnut:     |
+|     `force=`                                 | :green_apple: | :chestnut:     |
+| **`ipfs key rm`**                            | :green_apple: | :chestnut:     |
+|     `name`                                   | :green_apple: | :chestnut:     |
+|     `l=`                                     | :green_apple: | :chestnut:     |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl        |
+| -------------------------------------------- | :-----------: | :-----------:  |
+| **`GET /api/v0/key/gen`**                    | :green_apple: | :chestnut:     |
+|     `arg=`                                   | :green_apple: | :chestnut:     |
+|     `type=`                                  | :green_apple: | :chestnut:     |
+|     `size=`                                  | :green_apple: | :chestnut:     |
+| **`GET /api/v0/key/list`**                   | :green_apple: | :chestnut:     |
+|     `l=`                                     | :green_apple: | :chestnut:     |
+| **`GET /api/v0/key/rename`**                 | :green_apple: | :chestnut:     |
+|     `arg=`                                   | :green_apple: | :chestnut:     |
+|     `arg=`                                   | :green_apple: | :chestnut:     |
+|     `force=`                                 | :green_apple: | :chestnut:     |
+| **`GET /api/v0/key/rm`**                     | :green_apple: | :chestnut:     |
+|     `arg=`                                   | :green_apple: | :chestnut:     |
+|     `l=`                                     | :green_apple: | :chestnut:     |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Miscellaneous
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs ping`**                              | :green_apple: | :lemon:       |
+|     `peer ID`                                | :green_apple: | :tomato:      |
+|     `count`                                  | :green_apple: | :tomato:      |
+| **`ipfs update`**                            | :chestnut:    | :chestnut:    |
+| **`ipfs version`**                           | :green_apple: | :green_apple: |
+| **`ipfs commands`**                          | :green_apple: | :green_apple: |
+| **`ipfs id`**                                | :green_apple: | :green_apple: |
+|     `peerid`                                 | :green_apple: | :tomato:      |
+|     `aver`                                   | :green_apple: | :tomato:      |
+|     `pver`                                   | :green_apple: | :tomato:      |
+|     `pubkey`                                 | :green_apple: | :tomato:      |
+|     `addrs`                                  | :green_apple: | :tomato:      |
+| **`ipfs mount`**                             | :green_apple: | :chestnut:    |
+|     `ipfs-path=`                             | :green_apple: | :chestnut:    |
+|     `ipns-path=`                             | :green_apple: | :chestnut:    |
+| **`ipfs mount`**                             | :green_apple: | :chestnut:    |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/ping`**                       | :green_apple: | :lemon:       |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `count=`                                 | :green_apple: | :tomato:      |
+| **`GET /api/v0/update`**                     | :chestnut:    | :chestnut:    |
+| **`GET /api/v0/version`**                    | :green_apple: | :green_apple: |
+| **`GET /api/v0/commands`**                   | :green_apple: | :green_apple: |
+| **`POST /api/v0/id`**                        | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/mount`**                      | :green_apple: | :chestnut:    |
+|     `ipfs-path=`                             | :green_apple: | :chestnut:    |
+|     `ipns-path=`                             | :green_apple: | :chestnut:    |
+| **`GET /api/v0/mount`**                      | :green_apple: | :chestnut:    |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Naming
+
+> **Note:** Implementation in js-ipfs is blocked until DHT is finished.
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs name publish`**                      | :green_apple: | :tomato:      |
+|     `ipfs-path`                              | :green_apple: | :tomato:      |
+|     `resolve=`                               | :green_apple: | :tomato:      |
+|     `lifetime=`                              | :green_apple: | :tomato:      |
+|     `ttl=`                                   | :green_apple: | :tomato:      |
+|     `key=`                                   | :green_apple: | :tomato:      |
+| **`ipfs name resolve`**                      | :green_apple: | :tomato:      |
+|     `name`                                   | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+|     `nocache=`                               | :green_apple: | :tomato:      |
+| **`ipfs resolve`**                           | :green_apple: | :tomato:      |
+|     `name`                                   | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`ipfs dns`**                               | :green_apple: | :tomato:      |
+|     `domain`                                 | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`POST /api/v0/name/publish`**              | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `resolve=`                               | :green_apple: | :tomato:      |
+|     `lifetime=`                              | :green_apple: | :tomato:      |
+|     `ttl=`                                   | :green_apple: | :tomato:      |
+|     `key=`                                   | :green_apple: | :tomato:      |
+| **`GET /api/v0/name/resolve`**               | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+|     `nocache=`                               | :green_apple: | :tomato:      |
+| **`GET /api/v0/resolve`**                    | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`GET /api/v0/dns`**                        | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Object `ipfs object`
+
+#### CLI
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs object data`**                       | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+| **`ipfs object diff`**                       | :green_apple: | :tomato:      |
+|     `key1`                                   | :green_apple: | :tomato:      |
+|     `key2`                                   | :green_apple: | :tomato:      |
+| **`ipfs object/get`**                        | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+|     `encoding`                               | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/links`**               | :green_apple: | :green_apple: |
+|     `key`                                    | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/new`**                 | :green_apple: | :green_apple: |
+|     `template`                               | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/patch/append-data`**   | :green_apple: | :green_apple: |
+|     `root`                                   | :green_apple: | :green_apple: |
+|     `data`                                   | :green_apple: | :green_apple: |
+| **`POST /api/v0/object/patch/add-link`**     | :green_apple: | :green_apple: |
+|     `root`                                   | :green_apple: | :green_apple: |
+|     `name`                                   | :green_apple: | :green_apple: |
+|     `ref`                                    | :green_apple: | :lemon:       |
+|     `create`                                 | :green_apple: | :tomato:      |
+| **`POST /api/v0/object/patch/rm-link`**      | :green_apple: | :green_apple: |
+|     `root`                                   | :green_apple: | :green_apple: |
+|     `link`                                   | :green_apple: | :green_apple: |
+| **`POST /api/v0/object/patch/set-data`**     | :green_apple: | :green_apple: |
+|     `root`                                   | :green_apple: | :green_apple: |
+|     `data`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/put`**                 | :green_apple: | :green_apple: |
+|     `data`                                   | :green_apple: | :green_apple: |
+|     `inputenc`                               | :green_apple: | :green_apple: |
+|     `datafieldenc`                           | :green_apple: | :tomato:      |
+|     `pin`                                    | :green_apple: | :tomato:      |
+| **`GET /api/v0/object/stat`**                | :green_apple: | :green_apple: |
+|     `root`                                   | :green_apple: | :green_apple: |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/object/data`**                | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/diff`**                | :green_apple: | :tomato:      |
+|     `arg1=`                                  | :green_apple: | :tomato:      |
+|     `arg2=`                                  | :green_apple: | :tomato:      |
+| **`POST /api/v0/object/get`**                | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `encoding=json,enc=json`                 | :green_apple: | :green_apple: |
+|     `encoding=protobuf,enc=protobuf`         | :green_apple: | :green_apple: |
+|     `encoding=xml,enc=xml`                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/links`**               | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/new`**                 | :green_apple: | :green_apple: |
+|     `arg=unixfs-dir`                         | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/patch/append-data`**   | :green_apple: | :green_apple: |
+|     `arg1=`                                  | :green_apple: | :green_apple: |
+|     `arg2=`                                  | :green_apple: | :green_apple: |
+| **`POST /api/v0/object/patch/add-link`**     | :green_apple: | :green_apple: |
+|     `arg1=`                                  | :green_apple: | :green_apple: |
+|     `arg2=`                                  | :green_apple: | :green_apple: |
+|     `arg3=`                                  | :green_apple: | :green_apple: |
+|     `create=`                                | :green_apple: | :green_apple: |
+| **`POST /api/v0/object/patch/rm-link`**      | :green_apple: | :green_apple: |
+|     `arg1=`                                  | :green_apple: | :green_apple: |
+|     `arg2=`                                  | :green_apple: | :green_apple: |
+| **`POST /api/v0/object/patch/set-data`**     | :green_apple: | :green_apple: |
+|     `arg1=`                                  | :green_apple: | :green_apple: |
+|     `arg2=`                                  | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/put`**                 | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `inputenc`                               | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/stat`**                | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## p2p (libp2p exposed API)
+
+> **This is blocked until there is a formalized `interface-libp2p`**. Currently, js-ipfs exposes libp2p directly while go-ipfs exposes a subset of commands that use libp2p.
+
+#### CLI
+
+#### HTTP
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Pining
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs pin add`**                           | :green_apple: | :lemon:       |
+|     `hash`                                   | :green_apple: | :lemon:       |
+|     `recursive`                              | :green_apple: | :lemon:       |
+|     `progress`                               | :green_apple: | :tomato:      |
+| **`ipfs pin ls`**                            | :green_apple: | :lemon:       |
+|     `type`                                   | :green_apple: | :lemon:       |
+|     `quiet`                                  | :green_apple: | :lemon:       |
+| **`ipfs pin rm`**                            | :green_apple: | :lemon:       |
+|     `hash`                                   | :green_apple: | :lemon:       |
+|     `recursive`                              | :green_apple: | :lemon:       |
+| **`ipfs pin update`**                        | :green_apple: | :tomato:      |
+|     `hash`                                   | :green_apple: | :tomato:      |
+|     `unpin`                                  | :green_apple: | :tomato:      |
+| **`ipfs pin verify`**                        | :green_apple: | :tomato:      |
+|     `verbose`                                | :green_apple: | :tomato:      |
+| **`ipfs refs`**                              | :green_apple: | :tomato:      |
+|     `hash`                                   | :green_apple: | :tomato:      |
+|     `format`                                 | :green_apple: | :tomato:      |
+|     `edges`                                  | :green_apple: | :tomato:      |
+|     `unique`                                 | :green_apple: | :tomato:      |
+|     `recursive`                              | :green_apple: | :tomato:      |
+| **`ipfs refs local`**                        | :green_apple: | :tomato:      |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/pin/add`**                    | :green_apple: | :lemon:       |
+|     `arg=`                                   | :green_apple: | :lemon:       |
+|     `recursive=`                             | :green_apple: | :lemon:       |
+| **`POST /api/v0/pin/ls`**                    | :green_apple: | :lemon:       |
+|     `type=`                                  | :green_apple: | :tomato:      |
+|     `quiet=`                                 | :green_apple: | :tomato:      |
+| **`GET /api/v0/pin/rm`**                     | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`GET /api/v0/pin/update`**                 | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `unpin=`                                 | :green_apple: | :tomato:      |
+| **`GET /api/v0/pin/verify`**                 | :green_apple: | :tomato:      |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`GET /api/v0/refs`**                       | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+|     `format=`                                | :green_apple: | :tomato:      |
+|     `edges=`                                 | :green_apple: | :tomato:      |
+|     `unique=`                                | :green_apple: | :tomato:      |
+|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`GET /api/v0//refs/local`**                | :green_apple: | :tomato:      |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## PubSub
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs pubsub ls`**                         | :green_apple: | :green_apple: |
+| **`ipfs pubsub peers`**                      | :green_apple: | :green_apple: |
+|     `topic`                                  | :green_apple: | :green_apple: |
+| **`ipfs pubsub pub`**                        | :green_apple: | :green_apple: |
+|     `topic`                                  | :green_apple: | :green_apple: |
+|     `data`                                   | :green_apple: | :green_apple: |
+| **`ipfs pubsub sub`**                        | :green_apple: | :green_apple: |
+|     `topic`                                  | :green_apple: | :green_apple: |
+|     `discover`                               | :green_apple: | :tomato:      |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/pubsub/ls`**                  | :green_apple: | :green_apple: |
+| **`GET /api/v0/pubsub/peers`**               | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/pubsub/pub`**                 | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/pubsub/sub`**                 | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+|     `discover=`                              | :green_apple: | :green_apple: |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Repo
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs repo fsck`**                         | :green_apple: | :chestnut:    |
+| **`ipfs repo gc`**                           | :green_apple: | :tomato:      |
+| **`ipfs repo stat`**                         | :green_apple: | :tomato:      |
+| **`ipfs repo verify`**                       | :green_apple: | :chestnut:    |
+| **`ipfs repo version`**                      | :green_apple: | :green_apple: |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/repo/fsck`**                  | :green_apple: | :chestnut:    |
+| **`GET /api/v0/repo/gc`**                    | :green_apple: | :tomato:      |
+| **`GET /api/v0/repo/stat`**                  | :green_apple: | :tomato:      |
+| **`GET /api/v0/repo/verify`**                | :green_apple: | :chestnut:    |
+| **`GET /api/v0/repo/version`**               | :green_apple: | :green_apple: |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------
+
+## Swarm
+
+#### CLI
+
+| Command                                      | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`ipfs swarm addrs`**                       | :green_apple: | :green_apple: |
+| **`ipfs swarm addrs listen`**                | :green_apple: | :tomato:      |
+| **`ipfs swarm addrs local`**                 | :green_apple: | :green_apple: |
+|     `id=`                                    | :green_apple: | :tomato:      |
+| **`ipfs swarm connect`**                     | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`ipfs swarm disconnect`**                  | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`ipfs swarm filters`**                     | :green_apple: | :tomato:      |
+| **`ipfs swarm filters add`**                 | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+| **`ipfs swarm filters rm`**                  | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+| **`ipfs swarm peers`**                       | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+|     `latency=`                               | :green_apple: | :tomato:      |
+|     `streams=`                               | :green_apple: | :tomato:      |
+
+#### HTTP
+
+| Endpoint                                     | Go Impl       | JS Impl       |
+| -------------------------------------------- | :-----------: | :-----------: |
+| **`GET /api/v0/swarm/addrs`**                | :green_apple: | :green_apple: |
+| **`GET /api/v0/swarm/addrs/listen`**         | :green_apple: | :tomato:      |
+| **`GET /api/v0/swarm/addrs/local`**          | :green_apple: | :green_apple: |
+|     `id=`                                    | :green_apple: | :tomato:      |
+| **`GET /api/v0/swarm/connect`**              | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/swarm/disconnect`**           | :green_apple: | :green_apple: |
+|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/swarm/filters`**              | :green_apple: | :tomato:      |
+| **`GET /api/v0/swarm/filters/add`**          | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+| **`GET /api/v0/swarm/filters/rm`**           | :green_apple: | :tomato:      |
+|     `arg=`                                   | :green_apple: | :tomato:      |
+| **`GET /api/v0/swarm/peers`**                | :green_apple: | :green_apple: |
+|     `verbose=`                               | :green_apple: | :tomato:      |
+|     `latency=`                               | :green_apple: | :tomato:      |
+|     `streams=`                               | :green_apple: | :tomato:      |
+
+#### Core
+
+See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
+
+--------------------------------------------------------------------------------

--- a/docs/project/implementation-status.md
+++ b/docs/project/implementation-status.md
@@ -5,7 +5,7 @@ description: See the current status of various aspects of the core IPFS implemen
 
 # IPFS implementation status
 
-### Legend: :green_apple: Done &nbsp; :lemon: In Progress &nbsp; :tomato: Missing &nbsp; :chestnut: Not planned
+### Legend: :white_check_mark: Done &nbsp; :construction: In Progress &nbsp; :x: Missing &nbsp; :heavy_minus_sign: Not planned
 
 ## Bitswap
 
@@ -13,27 +13,27 @@ description: See the current status of various aspects of the core IPFS implemen
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs ledger`**                            | :green_apple: | :lemon:       |
-|     `peer`                                   | :green_apple: | :lemon:       |
-| **`ipfs reprovide`**                         | :green_apple: | :tomato:      |
-| **`ipfs bitswap stat`**                      | :green_apple: | :green_apple: |
-| **`ipfs bitswap unwant`**                    | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-| **`ipfs bitswap wantlist`**                  | :green_apple: | :green_apple: |
-|     `peer`                                   | :green_apple: | :green_apple: |
+| **`ipfs ledger`**                            | :white_check_mark: | :construction:       |
+|     `peer`                                   | :white_check_mark: | :construction:       |
+| **`ipfs reprovide`**                         | :white_check_mark: | :x:      |
+| **`ipfs bitswap stat`**                      | :white_check_mark: | :white_check_mark: |
+| **`ipfs bitswap unwant`**                    | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+| **`ipfs bitswap wantlist`**                  | :white_check_mark: | :white_check_mark: |
+|     `peer`                                   | :white_check_mark: | :white_check_mark: |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/bitswap/ledger`**             | :green_apple: | :lemon:       |
-|     `arg=`                                   | :green_apple: | :lemon:       |
-| **`GET /api/v0/bitswap/reprovide`**          | :green_apple: | :tomato:      |
-| **`GET /api/v0/bitswap/stat`**               | :green_apple: | :green_apple: |
-| **`GET /api/v0/bitswap/unwant`**             | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/bitswap/wantlist`**           | :green_apple: | :green_apple: |
-|     `peer=`                                  | :green_apple: | :green_apple: |
+| **`GET /api/v0/bitswap/ledger`**             | :white_check_mark: | :construction:       |
+|     `arg=`                                   | :white_check_mark: | :construction:       |
+| **`GET /api/v0/bitswap/reprovide`**          | :white_check_mark: | :x:      |
+| **`GET /api/v0/bitswap/stat`**               | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/bitswap/unwant`**             | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/bitswap/wantlist`**           | :white_check_mark: | :white_check_mark: |
+|     `peer=`                                  | :white_check_mark: | :white_check_mark: |
 
 ### Core
 
@@ -46,35 +46,35 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs block get`**                         | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-| **`ipfs block put`**                         | :green_apple: | :green_apple: |
-|     `data`                                   | :green_apple: | :green_apple: |
-|     `format`                                 | :green_apple: | :green_apple: |
-|     `mhtype`                                 | :green_apple: | :green_apple: |
-|     `mhlen`                                  | :green_apple: | :green_apple: |
-| **`ipfs block rm`**                          | :green_apple: | :lemon:       |
-|     `hash`                                   | :green_apple: | :lemon:       |
-|     `force`                                  | :green_apple: | :lemon:       |
-| **`ipfs block stat`**                        | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
+| **`ipfs block get`**                         | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+| **`ipfs block put`**                         | :white_check_mark: | :white_check_mark: |
+|     `data`                                   | :white_check_mark: | :white_check_mark: |
+|     `format`                                 | :white_check_mark: | :white_check_mark: |
+|     `mhtype`                                 | :white_check_mark: | :white_check_mark: |
+|     `mhlen`                                  | :white_check_mark: | :white_check_mark: |
+| **`ipfs block rm`**                          | :white_check_mark: | :construction:       |
+|     `hash`                                   | :white_check_mark: | :construction:       |
+|     `force`                                  | :white_check_mark: | :construction:       |
+| **`ipfs block stat`**                        | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/block/get`**                  | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`POST /api/v0/block/put`**                 | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `format=`                                | :green_apple: | :green_apple: |
-|     `mhtype=`                                | :green_apple: | :green_apple: |
-|     `mhlen=`                                 | :green_apple: | :green_apple: |
-| **`GET /api/v0/block/rm`**                   | :green_apple: | :lemon:       |
-|     `arg=`                                   | :green_apple: | :lemon:       |
-|     `force=`                                 | :green_apple: | :lemon:       |
-| **`GET /api/v0/block/stat`**                 | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/block/get`**                  | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/block/put`**                 | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `format=`                                | :white_check_mark: | :white_check_mark: |
+|     `mhtype=`                                | :white_check_mark: | :white_check_mark: |
+|     `mhlen=`                                 | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/block/rm`**                   | :white_check_mark: | :construction:       |
+|     `arg=`                                   | :white_check_mark: | :construction:       |
+|     `force=`                                 | :white_check_mark: | :construction:       |
+| **`GET /api/v0/block/stat`**                 | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
 
 ### Core
 
@@ -86,27 +86,27 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs bootstrap add`**                     | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `default=`                               | :green_apple: | :green_apple: |
-| **`ipfs bootstrap list`**                    | :green_apple: | :green_apple: |
-| **`ipfs bootstrap rm`**                      | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `all=`                                   | :green_apple: | :green_apple: |
+| **`ipfs bootstrap add`**                     | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `default=`                               | :white_check_mark: | :white_check_mark: |
+| **`ipfs bootstrap list`**                    | :white_check_mark: | :white_check_mark: |
+| **`ipfs bootstrap rm`**                      | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `all=`                                   | :white_check_mark: | :white_check_mark: |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/bootstrap/add`**              | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `default=`                               | :green_apple: | :green_apple: |
-| **`GET /api/v0/bootstrap/add/default`**      | :green_apple: | :tomato:      |
-| **`GET /api/v0/bootstrap/list`**             | :green_apple: | :green_apple: |
-| **`GET /api/v0/bootstrap/rm`**               | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `all=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/bootstrap/rm/all`**           | :green_apple: | :tomato:      |
+| **`GET /api/v0/bootstrap/add`**              | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `default=`                               | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/bootstrap/add/default`**      | :white_check_mark: | :x:      |
+| **`GET /api/v0/bootstrap/list`**             | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/bootstrap/rm`**               | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `all=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/bootstrap/rm/all`**           | :white_check_mark: | :x:      |
 
 ### Core
 
@@ -119,39 +119,39 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs config edit`**                       | :green_apple: | :chestnut:    |
-| **`ipfs config`**                            | :green_apple: | :chestnut:    |
-|     `key`                                    | :green_apple: | :green_apple: |
-|     `value`                                  | :green_apple: | :green_apple: |
-|     `bool=`                                  | :green_apple: | :green_apple: |
-|     `json=`                                  | :green_apple: | :green_apple: |
-| **`ipfs config replace`**                    | :green_apple: | :green_apple: |
-|     `file`                                   | :green_apple: | :green_apple: |
-| **`ipfs config show`**                       | :green_apple: | :green_apple: |
-| **`ipfs log level`**                         | :green_apple: | :chestnut:    |
-|     `subsystem`                              | :green_apple: | :chestnut:    |
-|     `level`                                  | :green_apple: | :chestnut:    |
-| **`ipfs log ls`**                            | :green_apple: | :chestnut:    |
-| **`ipfs log tail`**                          | :green_apple: | :chestnut:    |
+| **`ipfs config edit`**                       | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs config`**                            | :white_check_mark: | :heavy_minus_sign:    |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+|     `value`                                  | :white_check_mark: | :white_check_mark: |
+|     `bool=`                                  | :white_check_mark: | :white_check_mark: |
+|     `json=`                                  | :white_check_mark: | :white_check_mark: |
+| **`ipfs config replace`**                    | :white_check_mark: | :white_check_mark: |
+|     `file`                                   | :white_check_mark: | :white_check_mark: |
+| **`ipfs config show`**                       | :white_check_mark: | :white_check_mark: |
+| **`ipfs log level`**                         | :white_check_mark: | :heavy_minus_sign:    |
+|     `subsystem`                              | :white_check_mark: | :heavy_minus_sign:    |
+|     `level`                                  | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs log ls`**                            | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs log tail`**                          | :white_check_mark: | :heavy_minus_sign:    |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/config/edit`**                | :green_apple: | :chestnut:    |
-| **`POST /api/v0/config`**                    | :green_apple: | :chestnut:    |
-|     `arg1=`                                  | :green_apple: | :green_apple: |
-|     `arg2=`                                  | :green_apple: | :green_apple: |
-|     `bool=`                                  | :green_apple: | :green_apple: |
-|     `json=`                                  | :green_apple: | :green_apple: |
-| **`POST /api/v0/config/replace`**            | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/config/show`**                | :green_apple: | :green_apple: |
-| **`POST /api/v0/log/level`**                 | :green_apple: | :chestnut:    |
-|     `arg1=`                                  | :green_apple: | :chestnut:    |
-|     `arg2=`                                  | :green_apple: | :chestnut:    |
-| **`GET /api/v0/log/ls`**                     | :green_apple: | :chestnut:    |
-| **`GET /api/v0/log/tail`**                   | :green_apple: | :chestnut:    |
+| **`GET /api/v0/config/edit`**                | :white_check_mark: | :heavy_minus_sign:    |
+| **`POST /api/v0/config`**                    | :white_check_mark: | :heavy_minus_sign:    |
+|     `arg1=`                                  | :white_check_mark: | :white_check_mark: |
+|     `arg2=`                                  | :white_check_mark: | :white_check_mark: |
+|     `bool=`                                  | :white_check_mark: | :white_check_mark: |
+|     `json=`                                  | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/config/replace`**            | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/config/show`**                | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/log/level`**                 | :white_check_mark: | :heavy_minus_sign:    |
+|     `arg1=`                                  | :white_check_mark: | :heavy_minus_sign:    |
+|     `arg2=`                                  | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/log/ls`**                     | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/log/tail`**                   | :white_check_mark: | :heavy_minus_sign:    |
 
 ### Core
 
@@ -178,37 +178,37 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs stats bitswap`**                     | :green_apple: | :tomato:      |
-| **`ipfs stats bw`**                          | :green_apple: | :tomato:      |
-|     `peer`                                   | :green_apple: | :tomato:      |
-|     `proto`                                  | :green_apple: | :tomato:      |
-|     `poll`                                   | :green_apple: | :tomato:      |
-|     `interval `                              | :green_apple: | :tomato:      |
-| **`ipfs stats repo`**                        | :green_apple: | :tomato:      |
-| **`ipfs diag cmds`**                         | :green_apple: | :chestnut:    |
-| **`ipfs diag cmds clear`**                   | :green_apple: | :chestnut:    |
-| **`ipfs diag cmds set-time`**                | :green_apple: | :chestnut:    |
-|     `time`                                   | :green_apple: | :chestnut:    |
-| **`ipfs diag sys`**                          | :green_apple: | :chestnut:    |
+| **`ipfs stats bitswap`**                     | :white_check_mark: | :x:      |
+| **`ipfs stats bw`**                          | :white_check_mark: | :x:      |
+|     `peer`                                   | :white_check_mark: | :x:      |
+|     `proto`                                  | :white_check_mark: | :x:      |
+|     `poll`                                   | :white_check_mark: | :x:      |
+|     `interval `                              | :white_check_mark: | :x:      |
+| **`ipfs stats repo`**                        | :white_check_mark: | :x:      |
+| **`ipfs diag cmds`**                         | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs diag cmds clear`**                   | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs diag cmds set-time`**                | :white_check_mark: | :heavy_minus_sign:    |
+|     `time`                                   | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs diag sys`**                          | :white_check_mark: | :heavy_minus_sign:    |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/stats/bitswap`**              | :green_apple: | :tomato:      |
-| **`POST /api/v0/stats/bw`**                  | :green_apple: | :tomato:      |
-|     `peer=`                                  | :green_apple: | :tomato:      |
-|     `proto=`                                 | :green_apple: | :tomato:      |
-|     `poll=`                                  | :green_apple: | :tomato:      |
-|     `interval=`                              | :green_apple: | :tomato:      |
-| **`GET /api/v0/stats/repo`**                 | :green_apple: | :tomato:      |
-| **`GET /api/v0/diag/cmds`**                  | :green_apple: | :chestnut:    |
-| **`GET /api/v0/diag/cmds/clear`**            | :green_apple: | :chestnut:    |
-| **`GET /api/v0/diag/cmds/set-time`**         | :green_apple: | :chestnut:    |
-|     `arg=`                                   | :green_apple: | :chestnut:    |
-| **`GET /api/v0/net`**                        | :green_apple: | :chestnut:    |
-|     `vis`                                    | :green_apple: | :chestnut:    |
-| **`GET /api/v0/sys`**                        | :green_apple: | :chestnut:    |
+| **`GET /api/v0/stats/bitswap`**              | :white_check_mark: | :x:      |
+| **`POST /api/v0/stats/bw`**                  | :white_check_mark: | :x:      |
+|     `peer=`                                  | :white_check_mark: | :x:      |
+|     `proto=`                                 | :white_check_mark: | :x:      |
+|     `poll=`                                  | :white_check_mark: | :x:      |
+|     `interval=`                              | :white_check_mark: | :x:      |
+| **`GET /api/v0/stats/repo`**                 | :white_check_mark: | :x:      |
+| **`GET /api/v0/diag/cmds`**                  | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/diag/cmds/clear`**            | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/diag/cmds/set-time`**         | :white_check_mark: | :heavy_minus_sign:    |
+|     `arg=`                                   | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/net`**                        | :white_check_mark: | :heavy_minus_sign:    |
+|     `vis`                                    | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/sys`**                        | :white_check_mark: | :heavy_minus_sign:    |
 
 ### Core
 
@@ -220,53 +220,53 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs dht findpeer`**                      | :green_apple: | :green_apple: |
-|     `peer ID`                                | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-| **`ipfs dht findprovs`**                     | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-|     `num-providers=`                         | :green_apple: | :green_apple: |
-| **`ipfs dht get`**                           | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-| **`ipfs dht provide`**                       | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-| **`ipfs dht put`**                           | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-|     `value`                                  | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-| **`ipfs dht query`**                         | :green_apple: | :tomato:      |
-|     `peer ID`                                | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`ipfs dht findpeer`**                      | :white_check_mark: | :white_check_mark: |
+|     `peer ID`                                | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+| **`ipfs dht findprovs`**                     | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+|     `num-providers=`                         | :white_check_mark: | :white_check_mark: |
+| **`ipfs dht get`**                           | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+| **`ipfs dht provide`**                       | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+| **`ipfs dht put`**                           | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+|     `value`                                  | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+| **`ipfs dht query`**                         | :white_check_mark: | :x:      |
+|     `peer ID`                                | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/dht/findpeer`**               | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-| **`GET /api/v0/dht/findprovs`**              | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-|     `num-providers=`                         | :green_apple: | :green_apple: |
-| **`GET /api/v0/dht/get`**                    | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-| **`GET /api/v0/dht/provide`**                | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-| **`GET /api/v0/dht/put`**                    | :green_apple: | :green_apple: |
-|     `arg1=`                                  | :green_apple: | :green_apple: |
-|     `arg2=`                                  | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-| **`GET /api/v0/dht/query`**                  | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
+| **`GET /api/v0/dht/findpeer`**               | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+| **`GET /api/v0/dht/findprovs`**              | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+|     `num-providers=`                         | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/dht/get`**                    | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+| **`GET /api/v0/dht/provide`**                | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+| **`GET /api/v0/dht/put`**                    | :white_check_mark: | :white_check_mark: |
+|     `arg1=`                                  | :white_check_mark: | :white_check_mark: |
+|     `arg2=`                                  | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+| **`GET /api/v0/dht/query`**                  | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
 
 ### Core
 
@@ -279,159 +279,159 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs add`**                               | :green_apple: | :lemon:       |
-|     `file`                                   | :green_apple: | :green_apple: |
-|     `recursive`                              | :green_apple: | :green_apple: |
-|     `quiet`                                  | :green_apple: | :green_apple: |
-|     `quieter`                                | :green_apple: | :green_apple: |
-|     `silent`                                 | :green_apple: | :green_apple: |
-|     `progress`                               | :green_apple: | :green_apple: |
-|     `trickle`                                | :green_apple: | :green_apple: |
-|     `only-hash`                              | :green_apple: | :green_apple: |
-|     `wrap-with-directory`                    | :green_apple: | :green_apple: |
-|     `hidden`                                 | :green_apple: | :tomato:      |
-|     `chunker`                                | :green_apple: | :tomato:      |
-|     `pin`                                    | :green_apple: | :lemon:       |
-|     `raw-leaves`                             | :green_apple: | :tomato:      |
-|     `nocopy`                                 | :green_apple: | :tomato:      |
-|     `fscache`                                | :green_apple: | :tomato:      |
-|     `cid-version`                            | :green_apple: | :tomato:      |
-|     `hash`                                   | :green_apple: | :tomato:      |
-| **`ipfs cat`**                               | :green_apple: | :green_apple: |
-|     `arg`                                    | :green_apple: | :green_apple: |
-| **`ipfs ls`**                                | :green_apple: | :lemon:       |
-|     `arg`                                    | :green_apple: | :lemon:       |
-|     `headers`                                | :green_apple: | :lemon:       |
-|     `resolve-type`                           | :green_apple: | :lemon:       |
-| **`ipfs file ls`**                           | :green_apple: | :chestnut:    |
-|     `path`                                   | :green_apple: | :chestnut:    |
-| **`ipfs files cp`**                          | :green_apple: | :tomato:      |
-|     `src`                                    | :green_apple: | :tomato:      |
-|     `dst`                                    | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs files flush`**                       | :green_apple: | :tomato:      |
-|     `path`                                   | :green_apple: | :tomato:      |
-| **`ipfs files ls`**                          | :green_apple: | :tomato:      |
-|     `path`                                   | :green_apple: | :tomato:      |
-|     `level`                                  | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs files mkdir`**                       | :green_apple: | :tomato:      |
-|     `path`                                   | :green_apple: | :tomato:      |
-|     `parents`                                | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs files mv`**                          | :green_apple: | :tomato:      |
-|     `src`                                    | :green_apple: | :tomato:      |
-|     `dst`                                    | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs files read`**                        | :green_apple: | :tomato:      |
-|     `path`                                   | :green_apple: | :tomato:      |
-|     `offset`                                 | :green_apple: | :tomato:      |
-|     `count`                                  | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs files rm`**                          | :green_apple: | :tomato:      |
-|     `path`                                   | :green_apple: | :tomato:      |
-|     `recursive`                              | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs files stat`**                        | :green_apple: | :tomato:      |
-|     `path`                                   | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs files write`**                       | :green_apple: | :tomato:      |
-|     `path`                                   | :green_apple: | :tomato:      |
-|     `data`                                   | :green_apple: | :tomato:      |
-|     `offset`                                 | :green_apple: | :tomato:      |
-|     `create`                                 | :green_apple: | :tomato:      |
-|     `truncate`                               | :green_apple: | :tomato:      |
-|     `count`                                  | :green_apple: | :tomato:      |
-|     `flush`                                  | :green_apple: | :tomato:      |
-| **`ipfs get`**                               | :green_apple: | :green_apple: |
-|     `path`                                   | :green_apple: | :green_apple: |
-|     `archive`                                | :green_apple: | :tomato:      |
-|     `compress`                               | :green_apple: | :tomato:      |
-|     `compression-level`                      | :green_apple: | :tomato:      |
+| **`ipfs add`**                               | :white_check_mark: | :construction:       |
+|     `file`                                   | :white_check_mark: | :white_check_mark: |
+|     `recursive`                              | :white_check_mark: | :white_check_mark: |
+|     `quiet`                                  | :white_check_mark: | :white_check_mark: |
+|     `quieter`                                | :white_check_mark: | :white_check_mark: |
+|     `silent`                                 | :white_check_mark: | :white_check_mark: |
+|     `progress`                               | :white_check_mark: | :white_check_mark: |
+|     `trickle`                                | :white_check_mark: | :white_check_mark: |
+|     `only-hash`                              | :white_check_mark: | :white_check_mark: |
+|     `wrap-with-directory`                    | :white_check_mark: | :white_check_mark: |
+|     `hidden`                                 | :white_check_mark: | :x:      |
+|     `chunker`                                | :white_check_mark: | :x:      |
+|     `pin`                                    | :white_check_mark: | :construction:       |
+|     `raw-leaves`                             | :white_check_mark: | :x:      |
+|     `nocopy`                                 | :white_check_mark: | :x:      |
+|     `fscache`                                | :white_check_mark: | :x:      |
+|     `cid-version`                            | :white_check_mark: | :x:      |
+|     `hash`                                   | :white_check_mark: | :x:      |
+| **`ipfs cat`**                               | :white_check_mark: | :white_check_mark: |
+|     `arg`                                    | :white_check_mark: | :white_check_mark: |
+| **`ipfs ls`**                                | :white_check_mark: | :construction:       |
+|     `arg`                                    | :white_check_mark: | :construction:       |
+|     `headers`                                | :white_check_mark: | :construction:       |
+|     `resolve-type`                           | :white_check_mark: | :construction:       |
+| **`ipfs file ls`**                           | :white_check_mark: | :heavy_minus_sign:    |
+|     `path`                                   | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs files cp`**                          | :white_check_mark: | :x:      |
+|     `src`                                    | :white_check_mark: | :x:      |
+|     `dst`                                    | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs files flush`**                       | :white_check_mark: | :x:      |
+|     `path`                                   | :white_check_mark: | :x:      |
+| **`ipfs files ls`**                          | :white_check_mark: | :x:      |
+|     `path`                                   | :white_check_mark: | :x:      |
+|     `level`                                  | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs files mkdir`**                       | :white_check_mark: | :x:      |
+|     `path`                                   | :white_check_mark: | :x:      |
+|     `parents`                                | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs files mv`**                          | :white_check_mark: | :x:      |
+|     `src`                                    | :white_check_mark: | :x:      |
+|     `dst`                                    | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs files read`**                        | :white_check_mark: | :x:      |
+|     `path`                                   | :white_check_mark: | :x:      |
+|     `offset`                                 | :white_check_mark: | :x:      |
+|     `count`                                  | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs files rm`**                          | :white_check_mark: | :x:      |
+|     `path`                                   | :white_check_mark: | :x:      |
+|     `recursive`                              | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs files stat`**                        | :white_check_mark: | :x:      |
+|     `path`                                   | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs files write`**                       | :white_check_mark: | :x:      |
+|     `path`                                   | :white_check_mark: | :x:      |
+|     `data`                                   | :white_check_mark: | :x:      |
+|     `offset`                                 | :white_check_mark: | :x:      |
+|     `create`                                 | :white_check_mark: | :x:      |
+|     `truncate`                               | :white_check_mark: | :x:      |
+|     `count`                                  | :white_check_mark: | :x:      |
+|     `flush`                                  | :white_check_mark: | :x:      |
+| **`ipfs get`**                               | :white_check_mark: | :white_check_mark: |
+|     `path`                                   | :white_check_mark: | :white_check_mark: |
+|     `archive`                                | :white_check_mark: | :x:      |
+|     `compress`                               | :white_check_mark: | :x:      |
+|     `compression-level`                      | :white_check_mark: | :x:      |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`POST /api/v0/add`**                       | :green_apple: | :lemon:       |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `recursive=`                             | :green_apple: | :green_apple: |
-|     `quiet=`                                 | :green_apple: | :tomato:      |
-|     `quieter=`                               | :green_apple: | :tomato:      |
-|     `silent=`                                | :green_apple: | :tomato:      |
-|     `progress=`                              | :green_apple: | :green_apple: |
-|     `trickle=`                               | :green_apple: | :green_apple: |
-|     `only-hash=`                             | :green_apple: | :green_apple: |
-|     `wrap-with-directory`                    | :green_apple: | :green_apple: |
-|     `hidden`                                 | :green_apple: | :tomato:      |
-|     `chunker`                                | :green_apple: | :tomato:      |
-|     `pin`                                    | :green_apple: | :lemon:       |
-|     `raw-leaves`                             | :green_apple: | :tomato:      |
-|     `nocopy`                                 | :green_apple: | :tomato:      |
-|     `fscache`                                | :green_apple: | :tomato:      |
-|     `cid-version`                            | :green_apple: | :tomato:      |
-|     `hash`                                   | :green_apple: | :tomato:      |
-| **`GET /api/v0/cat`**                        | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/ls`**                         | :green_apple: | :lemon:       |
-|     `arg=`                                   | :green_apple: | :lemon:       |
-|     `headers=`                               | :green_apple: | :lemon:       |
-|     `resolve-type=`                          | :green_apple: | :lemon:       |
-| **`GET /api/v0/file/ls`**                    | :green_apple: | :chestnut:    |
-|     `arg=`                                   | :green_apple: | :chestnut:    |
-| **`GET /api/v0/files/cp`**                   | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `arg2=`                                  | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`GET /api/v0/files/flush`**                | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-| **`GET /api/v0/files/ls`**                   | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `l=`                                     | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`GET /api/v0/files/mkdir`**                | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `parents=,p=`                            | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`GET /api/v0/files/mv`**                   | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `arg2=`                                  | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`GET /api/v0/files/read`**                 | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `offset=,o=`                             | :green_apple: | :tomato:      |
-|     `count=,n=`                              | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`POST /api/v0/files/rm`**                  | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `recursive=,r=`                          | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`GET /api/v0/files/stat`**                 | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`POST /api/v0/files/write`**               | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `arg2=`                                  | :green_apple: | :tomato:      |
-|     `offset=,o=`                             | :green_apple: | :tomato:      |
-|     `create=,e=`                             | :green_apple: | :tomato:      |
-|     `truncate=,t=`                           | :green_apple: | :tomato:      |
-|     `count=,n=`                              | :green_apple: | :tomato:      |
-|     `flush=,f=`                              | :green_apple: | :tomato:      |
-| **`POST /api/v0/get`**                       | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `archive=`                               | :green_apple: | :tomato:      |
-|     `compress=`                              | :green_apple: | :tomato:      |
-|     `compression-level=-1`                   | :green_apple: | :tomato:      |
-|     `compression-level=0`                    | :green_apple: | :tomato:      |
-|     `compression-level=1`                    | :green_apple: | :tomato:      |
-|     `compression-level=2`                    | :green_apple: | :tomato:      |
-|     `compression-level=3`                    | :green_apple: | :tomato:      |
-|     `compression-level=4`                    | :green_apple: | :tomato:      |
-|     `compression-level=5`                    | :green_apple: | :tomato:      |
-|     `compression-level=6`                    | :green_apple: | :tomato:      |
-|     `compression-level=7`                    | :green_apple: | :tomato:      |
-|     `compression-level=8`                    | :green_apple: | :tomato:      |
-|     `compression-level=9`                    | :green_apple: | :tomato:      |
+| **`POST /api/v0/add`**                       | :white_check_mark: | :construction:       |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `recursive=`                             | :white_check_mark: | :white_check_mark: |
+|     `quiet=`                                 | :white_check_mark: | :x:      |
+|     `quieter=`                               | :white_check_mark: | :x:      |
+|     `silent=`                                | :white_check_mark: | :x:      |
+|     `progress=`                              | :white_check_mark: | :white_check_mark: |
+|     `trickle=`                               | :white_check_mark: | :white_check_mark: |
+|     `only-hash=`                             | :white_check_mark: | :white_check_mark: |
+|     `wrap-with-directory`                    | :white_check_mark: | :white_check_mark: |
+|     `hidden`                                 | :white_check_mark: | :x:      |
+|     `chunker`                                | :white_check_mark: | :x:      |
+|     `pin`                                    | :white_check_mark: | :construction:       |
+|     `raw-leaves`                             | :white_check_mark: | :x:      |
+|     `nocopy`                                 | :white_check_mark: | :x:      |
+|     `fscache`                                | :white_check_mark: | :x:      |
+|     `cid-version`                            | :white_check_mark: | :x:      |
+|     `hash`                                   | :white_check_mark: | :x:      |
+| **`GET /api/v0/cat`**                        | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/ls`**                         | :white_check_mark: | :construction:       |
+|     `arg=`                                   | :white_check_mark: | :construction:       |
+|     `headers=`                               | :white_check_mark: | :construction:       |
+|     `resolve-type=`                          | :white_check_mark: | :construction:       |
+| **`GET /api/v0/file/ls`**                    | :white_check_mark: | :heavy_minus_sign:    |
+|     `arg=`                                   | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/files/cp`**                   | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `arg2=`                                  | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`GET /api/v0/files/flush`**                | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+| **`GET /api/v0/files/ls`**                   | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `l=`                                     | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`GET /api/v0/files/mkdir`**                | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `parents=,p=`                            | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`GET /api/v0/files/mv`**                   | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `arg2=`                                  | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`GET /api/v0/files/read`**                 | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `offset=,o=`                             | :white_check_mark: | :x:      |
+|     `count=,n=`                              | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`POST /api/v0/files/rm`**                  | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `recursive=,r=`                          | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`GET /api/v0/files/stat`**                 | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`POST /api/v0/files/write`**               | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `arg2=`                                  | :white_check_mark: | :x:      |
+|     `offset=,o=`                             | :white_check_mark: | :x:      |
+|     `create=,e=`                             | :white_check_mark: | :x:      |
+|     `truncate=,t=`                           | :white_check_mark: | :x:      |
+|     `count=,n=`                              | :white_check_mark: | :x:      |
+|     `flush=,f=`                              | :white_check_mark: | :x:      |
+| **`POST /api/v0/get`**                       | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `archive=`                               | :white_check_mark: | :x:      |
+|     `compress=`                              | :white_check_mark: | :x:      |
+|     `compression-level=-1`                   | :white_check_mark: | :x:      |
+|     `compression-level=0`                    | :white_check_mark: | :x:      |
+|     `compression-level=1`                    | :white_check_mark: | :x:      |
+|     `compression-level=2`                    | :white_check_mark: | :x:      |
+|     `compression-level=3`                    | :white_check_mark: | :x:      |
+|     `compression-level=4`                    | :white_check_mark: | :x:      |
+|     `compression-level=5`                    | :white_check_mark: | :x:      |
+|     `compression-level=6`                    | :white_check_mark: | :x:      |
+|     `compression-level=7`                    | :white_check_mark: | :x:      |
+|     `compression-level=8`                    | :white_check_mark: | :x:      |
+|     `compression-level=9`                    | :white_check_mark: | :x:      |
 
 ### Core
 
@@ -456,37 +456,37 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl        |
 | -------------------------------------------- | :-----------: | :-----------:  |
-| **`ipfs key gen`**                           | :green_apple: | :chestnut:     |
-|     `name`                                   | :green_apple: | :chestnut:     |
-|     `type=`                                  | :green_apple: | :chestnut:     |
-|     `size=`                                  | :green_apple: | :chestnut:     |
-| **`ipfs key list`**                          | :green_apple: | :chestnut:     |
-|     `l=`                                     | :green_apple: | :chestnut:     |
-| **`ipfs key rename`**                        | :green_apple: | :chestnut:     |
-|     `name`                                   | :green_apple: | :chestnut:     |
-|     `newName`                                | :green_apple: | :chestnut:     |
-|     `force=`                                 | :green_apple: | :chestnut:     |
-| **`ipfs key rm`**                            | :green_apple: | :chestnut:     |
-|     `name`                                   | :green_apple: | :chestnut:     |
-|     `l=`                                     | :green_apple: | :chestnut:     |
+| **`ipfs key gen`**                           | :white_check_mark: | :heavy_minus_sign:     |
+|     `name`                                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `type=`                                  | :white_check_mark: | :heavy_minus_sign:     |
+|     `size=`                                  | :white_check_mark: | :heavy_minus_sign:     |
+| **`ipfs key list`**                          | :white_check_mark: | :heavy_minus_sign:     |
+|     `l=`                                     | :white_check_mark: | :heavy_minus_sign:     |
+| **`ipfs key rename`**                        | :white_check_mark: | :heavy_minus_sign:     |
+|     `name`                                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `newName`                                | :white_check_mark: | :heavy_minus_sign:     |
+|     `force=`                                 | :white_check_mark: | :heavy_minus_sign:     |
+| **`ipfs key rm`**                            | :white_check_mark: | :heavy_minus_sign:     |
+|     `name`                                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `l=`                                     | :white_check_mark: | :heavy_minus_sign:     |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl        |
 | -------------------------------------------- | :-----------: | :-----------:  |
-| **`GET /api/v0/key/gen`**                    | :green_apple: | :chestnut:     |
-|     `arg=`                                   | :green_apple: | :chestnut:     |
-|     `type=`                                  | :green_apple: | :chestnut:     |
-|     `size=`                                  | :green_apple: | :chestnut:     |
-| **`GET /api/v0/key/list`**                   | :green_apple: | :chestnut:     |
-|     `l=`                                     | :green_apple: | :chestnut:     |
-| **`GET /api/v0/key/rename`**                 | :green_apple: | :chestnut:     |
-|     `arg=`                                   | :green_apple: | :chestnut:     |
-|     `arg=`                                   | :green_apple: | :chestnut:     |
-|     `force=`                                 | :green_apple: | :chestnut:     |
-| **`GET /api/v0/key/rm`**                     | :green_apple: | :chestnut:     |
-|     `arg=`                                   | :green_apple: | :chestnut:     |
-|     `l=`                                     | :green_apple: | :chestnut:     |
+| **`GET /api/v0/key/gen`**                    | :white_check_mark: | :heavy_minus_sign:     |
+|     `arg=`                                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `type=`                                  | :white_check_mark: | :heavy_minus_sign:     |
+|     `size=`                                  | :white_check_mark: | :heavy_minus_sign:     |
+| **`GET /api/v0/key/list`**                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `l=`                                     | :white_check_mark: | :heavy_minus_sign:     |
+| **`GET /api/v0/key/rename`**                 | :white_check_mark: | :heavy_minus_sign:     |
+|     `arg=`                                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `arg=`                                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `force=`                                 | :white_check_mark: | :heavy_minus_sign:     |
+| **`GET /api/v0/key/rm`**                     | :white_check_mark: | :heavy_minus_sign:     |
+|     `arg=`                                   | :white_check_mark: | :heavy_minus_sign:     |
+|     `l=`                                     | :white_check_mark: | :heavy_minus_sign:     |
 
 ### Core
 
@@ -499,39 +499,39 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs ping`**                              | :green_apple: | :lemon:       |
-|     `peer ID`                                | :green_apple: | :tomato:      |
-|     `count`                                  | :green_apple: | :tomato:      |
-| **`ipfs update`**                            | :chestnut:    | :chestnut:    |
-| **`ipfs version`**                           | :green_apple: | :green_apple: |
-| **`ipfs commands`**                          | :green_apple: | :green_apple: |
-| **`ipfs id`**                                | :green_apple: | :green_apple: |
-|     `peerid`                                 | :green_apple: | :tomato:      |
-|     `aver`                                   | :green_apple: | :tomato:      |
-|     `pver`                                   | :green_apple: | :tomato:      |
-|     `pubkey`                                 | :green_apple: | :tomato:      |
-|     `addrs`                                  | :green_apple: | :tomato:      |
-| **`ipfs mount`**                             | :green_apple: | :chestnut:    |
-|     `ipfs-path=`                             | :green_apple: | :chestnut:    |
-|     `ipns-path=`                             | :green_apple: | :chestnut:    |
-| **`ipfs mount`**                             | :green_apple: | :chestnut:    |
+| **`ipfs ping`**                              | :white_check_mark: | :construction:       |
+|     `peer ID`                                | :white_check_mark: | :x:      |
+|     `count`                                  | :white_check_mark: | :x:      |
+| **`ipfs update`**                            | :heavy_minus_sign:    | :heavy_minus_sign:    |
+| **`ipfs version`**                           | :white_check_mark: | :white_check_mark: |
+| **`ipfs commands`**                          | :white_check_mark: | :white_check_mark: |
+| **`ipfs id`**                                | :white_check_mark: | :white_check_mark: |
+|     `peerid`                                 | :white_check_mark: | :x:      |
+|     `aver`                                   | :white_check_mark: | :x:      |
+|     `pver`                                   | :white_check_mark: | :x:      |
+|     `pubkey`                                 | :white_check_mark: | :x:      |
+|     `addrs`                                  | :white_check_mark: | :x:      |
+| **`ipfs mount`**                             | :white_check_mark: | :heavy_minus_sign:    |
+|     `ipfs-path=`                             | :white_check_mark: | :heavy_minus_sign:    |
+|     `ipns-path=`                             | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs mount`**                             | :white_check_mark: | :heavy_minus_sign:    |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/ping`**                       | :green_apple: | :lemon:       |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `count=`                                 | :green_apple: | :tomato:      |
-| **`GET /api/v0/update`**                     | :chestnut:    | :chestnut:    |
-| **`GET /api/v0/version`**                    | :green_apple: | :green_apple: |
-| **`GET /api/v0/commands`**                   | :green_apple: | :green_apple: |
-| **`POST /api/v0/id`**                        | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/mount`**                      | :green_apple: | :chestnut:    |
-|     `ipfs-path=`                             | :green_apple: | :chestnut:    |
-|     `ipns-path=`                             | :green_apple: | :chestnut:    |
-| **`GET /api/v0/mount`**                      | :green_apple: | :chestnut:    |
+| **`GET /api/v0/ping`**                       | :white_check_mark: | :construction:       |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `count=`                                 | :white_check_mark: | :x:      |
+| **`GET /api/v0/update`**                     | :heavy_minus_sign:    | :heavy_minus_sign:    |
+| **`GET /api/v0/version`**                    | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/commands`**                   | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/id`**                        | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/mount`**                      | :white_check_mark: | :heavy_minus_sign:    |
+|     `ipfs-path=`                             | :white_check_mark: | :heavy_minus_sign:    |
+|     `ipns-path=`                             | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/mount`**                      | :white_check_mark: | :heavy_minus_sign:    |
 
 ### Core
 
@@ -546,43 +546,43 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs name publish`**                      | :green_apple: | :tomato:      |
-|     `ipfs-path`                              | :green_apple: | :tomato:      |
-|     `resolve=`                               | :green_apple: | :tomato:      |
-|     `lifetime=`                              | :green_apple: | :tomato:      |
-|     `ttl=`                                   | :green_apple: | :tomato:      |
-|     `key=`                                   | :green_apple: | :tomato:      |
-| **`ipfs name resolve`**                      | :green_apple: | :tomato:      |
-|     `name`                                   | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-|     `nocache=`                               | :green_apple: | :tomato:      |
-| **`ipfs resolve`**                           | :green_apple: | :tomato:      |
-|     `name`                                   | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-| **`ipfs dns`**                               | :green_apple: | :tomato:      |
-|     `domain`                                 | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`ipfs name publish`**                      | :white_check_mark: | :x:      |
+|     `ipfs-path`                              | :white_check_mark: | :x:      |
+|     `resolve=`                               | :white_check_mark: | :x:      |
+|     `lifetime=`                              | :white_check_mark: | :x:      |
+|     `ttl=`                                   | :white_check_mark: | :x:      |
+|     `key=`                                   | :white_check_mark: | :x:      |
+| **`ipfs name resolve`**                      | :white_check_mark: | :x:      |
+|     `name`                                   | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+|     `nocache=`                               | :white_check_mark: | :x:      |
+| **`ipfs resolve`**                           | :white_check_mark: | :x:      |
+|     `name`                                   | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+| **`ipfs dns`**                               | :white_check_mark: | :x:      |
+|     `domain`                                 | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`POST /api/v0/name/publish`**              | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `resolve=`                               | :green_apple: | :tomato:      |
-|     `lifetime=`                              | :green_apple: | :tomato:      |
-|     `ttl=`                                   | :green_apple: | :tomato:      |
-|     `key=`                                   | :green_apple: | :tomato:      |
-| **`GET /api/v0/name/resolve`**               | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-|     `nocache=`                               | :green_apple: | :tomato:      |
-| **`GET /api/v0/resolve`**                    | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-| **`GET /api/v0/dns`**                        | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
+| **`POST /api/v0/name/publish`**              | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `resolve=`                               | :white_check_mark: | :x:      |
+|     `lifetime=`                              | :white_check_mark: | :x:      |
+|     `ttl=`                                   | :white_check_mark: | :x:      |
+|     `key=`                                   | :white_check_mark: | :x:      |
+| **`GET /api/v0/name/resolve`**               | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+|     `nocache=`                               | :white_check_mark: | :x:      |
+| **`GET /api/v0/resolve`**                    | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+| **`GET /api/v0/dns`**                        | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
 
 ### Core
 
@@ -595,77 +595,77 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs object data`**                       | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-| **`ipfs object diff`**                       | :green_apple: | :tomato:      |
-|     `key1`                                   | :green_apple: | :tomato:      |
-|     `key2`                                   | :green_apple: | :tomato:      |
-| **`ipfs object/get`**                        | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-|     `encoding`                               | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/links`**               | :green_apple: | :green_apple: |
-|     `key`                                    | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/new`**                 | :green_apple: | :green_apple: |
-|     `template`                               | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/patch/append-data`**   | :green_apple: | :green_apple: |
-|     `root`                                   | :green_apple: | :green_apple: |
-|     `data`                                   | :green_apple: | :green_apple: |
-| **`POST /api/v0/object/patch/add-link`**     | :green_apple: | :green_apple: |
-|     `root`                                   | :green_apple: | :green_apple: |
-|     `name`                                   | :green_apple: | :green_apple: |
-|     `ref`                                    | :green_apple: | :lemon:       |
-|     `create`                                 | :green_apple: | :tomato:      |
-| **`POST /api/v0/object/patch/rm-link`**      | :green_apple: | :green_apple: |
-|     `root`                                   | :green_apple: | :green_apple: |
-|     `link`                                   | :green_apple: | :green_apple: |
-| **`POST /api/v0/object/patch/set-data`**     | :green_apple: | :green_apple: |
-|     `root`                                   | :green_apple: | :green_apple: |
-|     `data`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/put`**                 | :green_apple: | :green_apple: |
-|     `data`                                   | :green_apple: | :green_apple: |
-|     `inputenc`                               | :green_apple: | :green_apple: |
-|     `datafieldenc`                           | :green_apple: | :tomato:      |
-|     `pin`                                    | :green_apple: | :tomato:      |
-| **`GET /api/v0/object/stat`**                | :green_apple: | :green_apple: |
-|     `root`                                   | :green_apple: | :green_apple: |
+| **`ipfs object data`**                       | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+| **`ipfs object diff`**                       | :white_check_mark: | :x:      |
+|     `key1`                                   | :white_check_mark: | :x:      |
+|     `key2`                                   | :white_check_mark: | :x:      |
+| **`ipfs object/get`**                        | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+|     `encoding`                               | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/links`**               | :white_check_mark: | :white_check_mark: |
+|     `key`                                    | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/new`**                 | :white_check_mark: | :white_check_mark: |
+|     `template`                               | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/patch/append-data`**   | :white_check_mark: | :white_check_mark: |
+|     `root`                                   | :white_check_mark: | :white_check_mark: |
+|     `data`                                   | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/object/patch/add-link`**     | :white_check_mark: | :white_check_mark: |
+|     `root`                                   | :white_check_mark: | :white_check_mark: |
+|     `name`                                   | :white_check_mark: | :white_check_mark: |
+|     `ref`                                    | :white_check_mark: | :construction:       |
+|     `create`                                 | :white_check_mark: | :x:      |
+| **`POST /api/v0/object/patch/rm-link`**      | :white_check_mark: | :white_check_mark: |
+|     `root`                                   | :white_check_mark: | :white_check_mark: |
+|     `link`                                   | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/object/patch/set-data`**     | :white_check_mark: | :white_check_mark: |
+|     `root`                                   | :white_check_mark: | :white_check_mark: |
+|     `data`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/put`**                 | :white_check_mark: | :white_check_mark: |
+|     `data`                                   | :white_check_mark: | :white_check_mark: |
+|     `inputenc`                               | :white_check_mark: | :white_check_mark: |
+|     `datafieldenc`                           | :white_check_mark: | :x:      |
+|     `pin`                                    | :white_check_mark: | :x:      |
+| **`GET /api/v0/object/stat`**                | :white_check_mark: | :white_check_mark: |
+|     `root`                                   | :white_check_mark: | :white_check_mark: |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/object/data`**                | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/diff`**                | :green_apple: | :tomato:      |
-|     `arg1=`                                  | :green_apple: | :tomato:      |
-|     `arg2=`                                  | :green_apple: | :tomato:      |
-| **`POST /api/v0/object/get`**                | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `encoding=json,enc=json`                 | :green_apple: | :green_apple: |
-|     `encoding=protobuf,enc=protobuf`         | :green_apple: | :green_apple: |
-|     `encoding=xml,enc=xml`                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/links`**               | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/new`**                 | :green_apple: | :green_apple: |
-|     `arg=unixfs-dir`                         | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/patch/append-data`**   | :green_apple: | :green_apple: |
-|     `arg1=`                                  | :green_apple: | :green_apple: |
-|     `arg2=`                                  | :green_apple: | :green_apple: |
-| **`POST /api/v0/object/patch/add-link`**     | :green_apple: | :green_apple: |
-|     `arg1=`                                  | :green_apple: | :green_apple: |
-|     `arg2=`                                  | :green_apple: | :green_apple: |
-|     `arg3=`                                  | :green_apple: | :green_apple: |
-|     `create=`                                | :green_apple: | :green_apple: |
-| **`POST /api/v0/object/patch/rm-link`**      | :green_apple: | :green_apple: |
-|     `arg1=`                                  | :green_apple: | :green_apple: |
-|     `arg2=`                                  | :green_apple: | :green_apple: |
-| **`POST /api/v0/object/patch/set-data`**     | :green_apple: | :green_apple: |
-|     `arg1=`                                  | :green_apple: | :green_apple: |
-|     `arg2=`                                  | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/put`**                 | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `inputenc`                               | :green_apple: | :green_apple: |
-| **`GET /api/v0/object/stat`**                | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
+| **`GET /api/v0/object/data`**                | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/diff`**                | :white_check_mark: | :x:      |
+|     `arg1=`                                  | :white_check_mark: | :x:      |
+|     `arg2=`                                  | :white_check_mark: | :x:      |
+| **`POST /api/v0/object/get`**                | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `encoding=json,enc=json`                 | :white_check_mark: | :white_check_mark: |
+|     `encoding=protobuf,enc=protobuf`         | :white_check_mark: | :white_check_mark: |
+|     `encoding=xml,enc=xml`                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/links`**               | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/new`**                 | :white_check_mark: | :white_check_mark: |
+|     `arg=unixfs-dir`                         | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/patch/append-data`**   | :white_check_mark: | :white_check_mark: |
+|     `arg1=`                                  | :white_check_mark: | :white_check_mark: |
+|     `arg2=`                                  | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/object/patch/add-link`**     | :white_check_mark: | :white_check_mark: |
+|     `arg1=`                                  | :white_check_mark: | :white_check_mark: |
+|     `arg2=`                                  | :white_check_mark: | :white_check_mark: |
+|     `arg3=`                                  | :white_check_mark: | :white_check_mark: |
+|     `create=`                                | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/object/patch/rm-link`**      | :white_check_mark: | :white_check_mark: |
+|     `arg1=`                                  | :white_check_mark: | :white_check_mark: |
+|     `arg2=`                                  | :white_check_mark: | :white_check_mark: |
+| **`POST /api/v0/object/patch/set-data`**     | :white_check_mark: | :white_check_mark: |
+|     `arg1=`                                  | :white_check_mark: | :white_check_mark: |
+|     `arg2=`                                  | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/put`**                 | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `inputenc`                               | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/object/stat`**                | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
 
 ### Core
 
@@ -691,54 +691,54 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs pin add`**                           | :green_apple: | :lemon:       |
-|     `hash`                                   | :green_apple: | :lemon:       |
-|     `recursive`                              | :green_apple: | :lemon:       |
-|     `progress`                               | :green_apple: | :tomato:      |
-| **`ipfs pin ls`**                            | :green_apple: | :lemon:       |
-|     `type`                                   | :green_apple: | :lemon:       |
-|     `quiet`                                  | :green_apple: | :lemon:       |
-| **`ipfs pin rm`**                            | :green_apple: | :lemon:       |
-|     `hash`                                   | :green_apple: | :lemon:       |
-|     `recursive`                              | :green_apple: | :lemon:       |
-| **`ipfs pin update`**                        | :green_apple: | :tomato:      |
-|     `hash`                                   | :green_apple: | :tomato:      |
-|     `unpin`                                  | :green_apple: | :tomato:      |
-| **`ipfs pin verify`**                        | :green_apple: | :tomato:      |
-|     `verbose`                                | :green_apple: | :tomato:      |
-| **`ipfs refs`**                              | :green_apple: | :tomato:      |
-|     `hash`                                   | :green_apple: | :tomato:      |
-|     `format`                                 | :green_apple: | :tomato:      |
-|     `edges`                                  | :green_apple: | :tomato:      |
-|     `unique`                                 | :green_apple: | :tomato:      |
-|     `recursive`                              | :green_apple: | :tomato:      |
-| **`ipfs refs local`**                        | :green_apple: | :tomato:      |
+| **`ipfs pin add`**                           | :white_check_mark: | :construction:       |
+|     `hash`                                   | :white_check_mark: | :construction:       |
+|     `recursive`                              | :white_check_mark: | :construction:       |
+|     `progress`                               | :white_check_mark: | :x:      |
+| **`ipfs pin ls`**                            | :white_check_mark: | :construction:       |
+|     `type`                                   | :white_check_mark: | :construction:       |
+|     `quiet`                                  | :white_check_mark: | :construction:       |
+| **`ipfs pin rm`**                            | :white_check_mark: | :construction:       |
+|     `hash`                                   | :white_check_mark: | :construction:       |
+|     `recursive`                              | :white_check_mark: | :construction:       |
+| **`ipfs pin update`**                        | :white_check_mark: | :x:      |
+|     `hash`                                   | :white_check_mark: | :x:      |
+|     `unpin`                                  | :white_check_mark: | :x:      |
+| **`ipfs pin verify`**                        | :white_check_mark: | :x:      |
+|     `verbose`                                | :white_check_mark: | :x:      |
+| **`ipfs refs`**                              | :white_check_mark: | :x:      |
+|     `hash`                                   | :white_check_mark: | :x:      |
+|     `format`                                 | :white_check_mark: | :x:      |
+|     `edges`                                  | :white_check_mark: | :x:      |
+|     `unique`                                 | :white_check_mark: | :x:      |
+|     `recursive`                              | :white_check_mark: | :x:      |
+| **`ipfs refs local`**                        | :white_check_mark: | :x:      |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/pin/add`**                    | :green_apple: | :lemon:       |
-|     `arg=`                                   | :green_apple: | :lemon:       |
-|     `recursive=`                             | :green_apple: | :lemon:       |
-| **`POST /api/v0/pin/ls`**                    | :green_apple: | :lemon:       |
-|     `type=`                                  | :green_apple: | :tomato:      |
-|     `quiet=`                                 | :green_apple: | :tomato:      |
-| **`GET /api/v0/pin/rm`**                     | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-| **`GET /api/v0/pin/update`**                 | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `unpin=`                                 | :green_apple: | :tomato:      |
-| **`GET /api/v0/pin/verify`**                 | :green_apple: | :tomato:      |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-| **`GET /api/v0/refs`**                       | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-|     `format=`                                | :green_apple: | :tomato:      |
-|     `edges=`                                 | :green_apple: | :tomato:      |
-|     `unique=`                                | :green_apple: | :tomato:      |
-|     `recursive=`                             | :green_apple: | :tomato:      |
-| **`GET /api/v0//refs/local`**                | :green_apple: | :tomato:      |
+| **`GET /api/v0/pin/add`**                    | :white_check_mark: | :construction:       |
+|     `arg=`                                   | :white_check_mark: | :construction:       |
+|     `recursive=`                             | :white_check_mark: | :construction:       |
+| **`POST /api/v0/pin/ls`**                    | :white_check_mark: | :construction:       |
+|     `type=`                                  | :white_check_mark: | :x:      |
+|     `quiet=`                                 | :white_check_mark: | :x:      |
+| **`GET /api/v0/pin/rm`**                     | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+| **`GET /api/v0/pin/update`**                 | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `unpin=`                                 | :white_check_mark: | :x:      |
+| **`GET /api/v0/pin/verify`**                 | :white_check_mark: | :x:      |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+| **`GET /api/v0/refs`**                       | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+|     `format=`                                | :white_check_mark: | :x:      |
+|     `edges=`                                 | :white_check_mark: | :x:      |
+|     `unique=`                                | :white_check_mark: | :x:      |
+|     `recursive=`                             | :white_check_mark: | :x:      |
+| **`GET /api/v0//refs/local`**                | :white_check_mark: | :x:      |
 
 ### Core
 
@@ -751,29 +751,29 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs pubsub ls`**                         | :green_apple: | :green_apple: |
-| **`ipfs pubsub peers`**                      | :green_apple: | :green_apple: |
-|     `topic`                                  | :green_apple: | :green_apple: |
-| **`ipfs pubsub pub`**                        | :green_apple: | :green_apple: |
-|     `topic`                                  | :green_apple: | :green_apple: |
-|     `data`                                   | :green_apple: | :green_apple: |
-| **`ipfs pubsub sub`**                        | :green_apple: | :green_apple: |
-|     `topic`                                  | :green_apple: | :green_apple: |
-|     `discover`                               | :green_apple: | :tomato:      |
+| **`ipfs pubsub ls`**                         | :white_check_mark: | :white_check_mark: |
+| **`ipfs pubsub peers`**                      | :white_check_mark: | :white_check_mark: |
+|     `topic`                                  | :white_check_mark: | :white_check_mark: |
+| **`ipfs pubsub pub`**                        | :white_check_mark: | :white_check_mark: |
+|     `topic`                                  | :white_check_mark: | :white_check_mark: |
+|     `data`                                   | :white_check_mark: | :white_check_mark: |
+| **`ipfs pubsub sub`**                        | :white_check_mark: | :white_check_mark: |
+|     `topic`                                  | :white_check_mark: | :white_check_mark: |
+|     `discover`                               | :white_check_mark: | :x:      |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/pubsub/ls`**                  | :green_apple: | :green_apple: |
-| **`GET /api/v0/pubsub/peers`**               | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/pubsub/pub`**                 | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/pubsub/sub`**                 | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-|     `discover=`                              | :green_apple: | :green_apple: |
+| **`GET /api/v0/pubsub/ls`**                  | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/pubsub/peers`**               | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/pubsub/pub`**                 | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/pubsub/sub`**                 | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+|     `discover=`                              | :white_check_mark: | :white_check_mark: |
 
 ### Core
 
@@ -786,21 +786,21 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs repo fsck`**                         | :green_apple: | :chestnut:    |
-| **`ipfs repo gc`**                           | :green_apple: | :tomato:      |
-| **`ipfs repo stat`**                         | :green_apple: | :tomato:      |
-| **`ipfs repo verify`**                       | :green_apple: | :chestnut:    |
-| **`ipfs repo version`**                      | :green_apple: | :green_apple: |
+| **`ipfs repo fsck`**                         | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs repo gc`**                           | :white_check_mark: | :x:      |
+| **`ipfs repo stat`**                         | :white_check_mark: | :x:      |
+| **`ipfs repo verify`**                       | :white_check_mark: | :heavy_minus_sign:    |
+| **`ipfs repo version`**                      | :white_check_mark: | :white_check_mark: |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/repo/fsck`**                  | :green_apple: | :chestnut:    |
-| **`GET /api/v0/repo/gc`**                    | :green_apple: | :tomato:      |
-| **`GET /api/v0/repo/stat`**                  | :green_apple: | :tomato:      |
-| **`GET /api/v0/repo/verify`**                | :green_apple: | :chestnut:    |
-| **`GET /api/v0/repo/version`**               | :green_apple: | :green_apple: |
+| **`GET /api/v0/repo/fsck`**                  | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/repo/gc`**                    | :white_check_mark: | :x:      |
+| **`GET /api/v0/repo/stat`**                  | :white_check_mark: | :x:      |
+| **`GET /api/v0/repo/verify`**                | :white_check_mark: | :heavy_minus_sign:    |
+| **`GET /api/v0/repo/version`**               | :white_check_mark: | :white_check_mark: |
 
 ### Core
 
@@ -813,45 +813,45 @@ See [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core).
 
 | Command                                      | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`ipfs swarm addrs`**                       | :green_apple: | :green_apple: |
-| **`ipfs swarm addrs listen`**                | :green_apple: | :tomato:      |
-| **`ipfs swarm addrs local`**                 | :green_apple: | :green_apple: |
-|     `id=`                                    | :green_apple: | :tomato:      |
-| **`ipfs swarm connect`**                     | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`ipfs swarm disconnect`**                  | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`ipfs swarm filters`**                     | :green_apple: | :tomato:      |
-| **`ipfs swarm filters add`**                 | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-| **`ipfs swarm filters rm`**                  | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-| **`ipfs swarm peers`**                       | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-|     `latency=`                               | :green_apple: | :tomato:      |
-|     `streams=`                               | :green_apple: | :tomato:      |
+| **`ipfs swarm addrs`**                       | :white_check_mark: | :white_check_mark: |
+| **`ipfs swarm addrs listen`**                | :white_check_mark: | :x:      |
+| **`ipfs swarm addrs local`**                 | :white_check_mark: | :white_check_mark: |
+|     `id=`                                    | :white_check_mark: | :x:      |
+| **`ipfs swarm connect`**                     | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`ipfs swarm disconnect`**                  | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`ipfs swarm filters`**                     | :white_check_mark: | :x:      |
+| **`ipfs swarm filters add`**                 | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+| **`ipfs swarm filters rm`**                  | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+| **`ipfs swarm peers`**                       | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+|     `latency=`                               | :white_check_mark: | :x:      |
+|     `streams=`                               | :white_check_mark: | :x:      |
 
 ### HTTP
 
 | Endpoint                                     | Go Impl       | JS Impl       |
 | -------------------------------------------- | :-----------: | :-----------: |
-| **`GET /api/v0/swarm/addrs`**                | :green_apple: | :green_apple: |
-| **`GET /api/v0/swarm/addrs/listen`**         | :green_apple: | :tomato:      |
-| **`GET /api/v0/swarm/addrs/local`**          | :green_apple: | :green_apple: |
-|     `id=`                                    | :green_apple: | :tomato:      |
-| **`GET /api/v0/swarm/connect`**              | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/swarm/disconnect`**           | :green_apple: | :green_apple: |
-|     `arg=`                                   | :green_apple: | :green_apple: |
-| **`GET /api/v0/swarm/filters`**              | :green_apple: | :tomato:      |
-| **`GET /api/v0/swarm/filters/add`**          | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-| **`GET /api/v0/swarm/filters/rm`**           | :green_apple: | :tomato:      |
-|     `arg=`                                   | :green_apple: | :tomato:      |
-| **`GET /api/v0/swarm/peers`**                | :green_apple: | :green_apple: |
-|     `verbose=`                               | :green_apple: | :tomato:      |
-|     `latency=`                               | :green_apple: | :tomato:      |
-|     `streams=`                               | :green_apple: | :tomato:      |
+| **`GET /api/v0/swarm/addrs`**                | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/swarm/addrs/listen`**         | :white_check_mark: | :x:      |
+| **`GET /api/v0/swarm/addrs/local`**          | :white_check_mark: | :white_check_mark: |
+|     `id=`                                    | :white_check_mark: | :x:      |
+| **`GET /api/v0/swarm/connect`**              | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/swarm/disconnect`**           | :white_check_mark: | :white_check_mark: |
+|     `arg=`                                   | :white_check_mark: | :white_check_mark: |
+| **`GET /api/v0/swarm/filters`**              | :white_check_mark: | :x:      |
+| **`GET /api/v0/swarm/filters/add`**          | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+| **`GET /api/v0/swarm/filters/rm`**           | :white_check_mark: | :x:      |
+|     `arg=`                                   | :white_check_mark: | :x:      |
+| **`GET /api/v0/swarm/peers`**                | :white_check_mark: | :white_check_mark: |
+|     `verbose=`                               | :white_check_mark: | :x:      |
+|     `latency=`                               | :white_check_mark: | :x:      |
+|     `streams=`                               | :white_check_mark: | :x:      |
 
 ### Core
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,0 +1,793 @@
+---
+title: IPFS project requirements to 1.0.0
+description: Learn about the milestones in the IPFS project in order to reach version 1.0.0.
+---
+
+# IPFS Project Requirements to 1.0.0
+
+## Description
+
+In order for IPFS to reach its maturity state, going from Alpha, to Beta and to v1.0.0, the project will need:
+
+- For its specifications to be 100% complete. This includes the IPFS, libp2p, multiformats and IPLD specs.
+- Compliance tests for the specification.
+- The golang and JavaScript implementations to be 100% complete and spec compliant.
+- A third party implementation of IPFS, fully interoperable with the go and JavaScript versions.
+- A release plan and cycle, including a strategy to support specific key releases for longer periods of time (i.e LTS releases vs stable)
+
+## Milestones
+
+Here you will find a comprehensive list of the various challenges and milestones in the IPFS Project to reach version 1.0.0. They are not ordered in any way at the moment, merely grouped.
+
+### Sustainability and Governance
+
+These are some of the milestones to hit to create a active, sustainable, inclusive and participatory governance model for IPFS.
+
+- [x] Organize IPFS All Hands.
+- [ ] Have IPFS lead by a Steering Working Group.
+- [ ] Define several Working Groups focused on different parts of the project (e.g Community Engagement, Documentation and Education, IPFS in Web Browsers).
+- [ ] Define a release plan and long term support plan.
+
+### IPFS Use Cases
+
+These are some use case milestones to drive development.
+
+- [x] Support for file distribution
+  - [x] Support for personal file storage, backups, and distribution
+  - [x] Support for basic p2p file distribution
+  - [x] Support for fast local area network file distribution
+- [x] Support for immutable, permanent links to files, websites, data
+- [x] Support for mutable links to files, websites, data
+- [x] Support for websites and web applications
+  - [x] Support for static web applications
+  - [x] Support for API based web applications
+  - [x] Support for fully dynamic websites entirely on IPFS (eg chat)
+- [x] Support for collaborative seeding/pinning
+  - [x] basic support for ipfs ref pinning
+  - [ ] Cloud ipfs frontend services (cube)
+  - [ ] clusters of ipfs nodes (RAID/RAIN)
+  - [ ] byzantine clusters (BA)
+- [x] Support for browsers
+  - [x] js-ipfs-api client inside a tab
+  - [x] js-ipfs full node inside a tab
+  - [x] browser extension gateway redirects
+  - [x] browser extension full node
+  - [ ] impl native inside browsers
+- [x] Support for versioning and archival
+  - [x] archival of files
+  - [x] archival of data and databases
+  - [ ] commit based versioning
+- [x] Support other tools or applications via APIs
+  - [x] Support for commandline API usage
+  - [x] Support for HTTP API usage
+  - [ ] Support for unix sockets RPC API usage
+  - [x] Support for embedded, programmatic API usage
+  - [x] Support for HTTP Gateway
+
+### Performance Milestones
+
+These are some basic performance milestones to hit.
+
+- [x] Megabytes / Slow
+  - [x] Good enough for small files - MB
+  - [x] Good enough for static websites - MB
+  - [x] Good enough for distributing webapp code/assets - MB
+  - [x] Good enough for images - MB
+- [x] Gigabytes
+  - [x] Good enough for personal documents - GB
+  - [x] Good enough to stream video on the web - GB
+  - [x] Good enough for small scientific datasets - GB
+  - [x] Good enough for distributing webapp user data - GB
+- [ ] Terabytes
+  - [x] Good enough for image collections - TB
+  - [x] Good enough for small video collections - TB
+  - [ ] Good enough for medium scientific datasets - TB
+  - [x] Good enough as a package manager (gx) - TB
+  - [x] Good enough as a package manager backup (npm-on-ipfs) - TB
+  - [ ] Good enough as a package manager replacement (npm-on-ipfs) - TB
+  - [x] Good enough to distribute small databases - TB
+  - [ ] Good enough for large (single) archives - TB
+- [ ] Petabytes
+  - [ ] Good enough for large video collections - PB
+  - [ ] Good enough for large scientific datasets - PB
+  - [ ] Good enough for Backup Archival - TB/PB
+  - [ ] Good enough to distribute large databases - PB
+- [ ] Exabytes
+  - [ ] Good enough for massive archives - EB
+  - [ ] Good enough for the entire web - EB
+  - [ ] Good enough for top10 websites - EB
+
+### Developer Libraries
+
+These are some libraries that must exist to make developers' lives easy. It is critical that making fully dynamic apps on IPFS should be just as easy or easier than traditional systems.
+
+- [x] file importers for basic files
+- [x] custom file importer tooling
+- [x] ipfs node api bindings
+  - [x] ipfs api bindings in Go
+  - [x] ipfs api bindings in JS
+  - [x] ipfs api bindings in Java
+  - [x] ipfs api bindings in Python
+  - [x] ipfs api bindings in PHP
+  - [x] ipfs api bindings in Ruby
+  - [ ] ipfs api bindings in Scala
+  - [ ] ipfs api bindings in Rust
+  - [ ] ipfs api bindings in Haskell
+  - [x] ipfs api bindings in C/C++
+  - [ ] ipfs api bindings in Erlang
+- [x] full ipfs node implementations
+  - [x] go-ipfs - implementation in Go
+  - [x] js-ipfs - implementation in JS
+- [x] developer libs for cli tools
+- [ ] developer libs for desktop apps
+- [x] developer libs for webapps
+  - [x] js-ipfs-api - js api bindings
+- [ ] developer libs for mobile apps
+  - [ ] developer libs for iOS
+  - [ ] developer libs for Android
+- [x] developer libs for node.js apps
+  - [x] go-ipfs-dep - module to install go-ipfs
+  - [x] ipfsd-ctl - module to control an ipfs daemon
+  - [x] js-ipfs-api - js api bindings
+- [ ] developer libs for dynamic webapps (in progress)
+  - [x] ipfs-log (CRDT)
+  - [ ] other "CRDTs on IPFS" libs
+  - [x] orbit-db - key-value store and event log
+- [ ] developer libs for crypto capabilities
+  - [ ] typical sharing models over ipfs
+- [ ] developer libs for social networks
+  - [ ] POST datastructure
+  - [ ] decentralized identity
+
+### Security Milestones
+
+- [ ] Network security
+  - [x] upgradable transport encryption (multistream)
+  - [x] transport encryption: secio (ECDHE)
+  - [ ] transport encryption: TLS 1.3 (mainstream crypto)
+  - [ ] transport encryption: CurveCP or MinimaLT (djb crypto)
+- [ ] Content Security
+  - [x] content security: IPLD hash links (authenticated content)
+  - [ ] content security: Keychain signed objects
+  - [ ] content security: native content encryption
+  - [ ] content security: native crypto capabilities
+  - [ ] content security: audit
+- [ ] Anonymity
+  - [ ] transport anonymity: tor support
+  - [ ] transport anonymity: i2p support
+  - [ ] ship anonymity focused distribution (tor, i2p, no leaking info)
+  - [ ] peer and content routing anonymity
+  - [ ] anonymity: audit
+- [ ] Anticensorship
+  - [x] Anticensorship: decentralized, peering content distribution
+  - [x] Anticensorship: access based re-distribution
+  - [ ] Anticensorship: incentivized distribution
+  - [ ] Anticensorship: PKI distribution
+  - [ ] Anticensorship: resilience to powerful sybil attacks on routing
+  - [ ] Anticensorship: HTTP TLS transport emulation
+- [ ] Auditing
+  - [ ] Audit: full protocol fuzzer tests
+  - [ ] Audit: test with state of the art exploit test suites
+  - [ ] Audit: p2p scalability researcher audits
+  - [ ] Audit: 3x independent professional security audits of full protocol
+  - [ ] Audit: 3x independent professional security audits of implementations
+
+### Network Scalability
+
+The scalability of the IPFS protocol depends on careful design of algorithms and models, careful optimization of our implementations, and careful attention to the security properties of the protocols. Reaching high scalability for self-organizing peer-to-peer protocols is HARD, though definitely achievable. We measure scalability in orders of magnitude, as larger thresholds will require revisiting various parts of our codebase.
+
+Please bear in mind that we are currently still implementing major features of the protocols and reaching implementation completion. We have not yet turned our focus towards scalability, thus there are LOTS of low hanging fruit to optimize and likely many scalability bugs to be worked out. The most important part is to make sure all protocols are meant to scale to billions of nodes, and that they make no centralizing assumptions. All protocols we have chosen make no small scale assumptions and are meant to scale well (typically `log(n)`).
+
+Our scalability observations are divided into simulations, real network tests, and production networks.
+
+- [x] Simulations
+  - [x] Scalability to 1,000s of nodes
+  - [x] Scalability to 10,000s of nodes
+  - [x] Scalability to 100,000s of nodes
+  - [ ] Scalability to 1,000,000s of nodes
+  - [ ] Scalability to 1,000,000,000s of nodes
+- [x] Real network tests
+  - [x] Scalability to 1,000s of nodes
+  - [x] Scalability to 10,000s of nodes
+  - [ ] Scalability to 100,000s of nodes
+  - [ ] Scalability to 1,000,000s of nodes
+  - [ ] Scalability to 1,000,000,000s of nodes
+- [x] Production networks
+  - [x] Scalability to 1,000s of nodes
+  - [x] Scalability to 10,000s of nodes
+  - [ ] Scalability to 100,000s of nodes
+  - [ ] Scalability to 1,000,000s of nodes
+  - [ ] Scalability to 1,000,000,000s of nodes
+
+### Polish level
+
+The polish level achieved defined how much effort has gone into polishing all the corners of the tools, APIs, documentation, and so on. Early on, things will be much more rough as we need to focus on implementation speed over final polish. As we reach completion of the implementations, we turn our focus towards scalability, stability, and security. After that, we focus on end user polish.
+
+- [x] Polish level: alpha - individuals innovators
+- [x] Polish level: alpha - production for early adopters
+- [ ] Polish level: beta - production for small orgs (in progress)
+- [ ] Polish level: beta - production for large orgs
+- [ ] Polish level: 1.0 - production for all
+
+
+### Multiformats
+
+The multiformats are a set of self-describing protocols/formats for future-proofed or "upgradable systems" (systems that make no silly assumptions that are likely to break over time).
+
+- [x] multiaddr: protocol design
+  - [x] multiaddr: impl in Go
+  - [x] multiaddr: impl in JS
+  - [x] multiaddr: impl in Java
+  - [x] multiaddr: impl in Haskell
+  - [x] multiaddr: impl in Python
+  - [x] multiaddr: impl in Rust
+- [x] multihash: protocol spec
+  - [x] multihash: impl in Go
+  - [x] multihash: impl in JS
+  - [x] multihash: impl in Scala
+  - [x] multihash: impl in Java
+  - [x] multihash: impl in Clojure
+  - [x] multihash: impl in Rust
+  - [x] multihash: impl in Haskell
+  - [x] multihash: impl in Python
+  - [x] multihash: impl in Elixir
+  - [x] multihash: impl in Swift
+  - [x] multihash: impl in Ruby
+- [x] multicodec: protocol spec
+  - [x] multicodec: impl in Go
+  - [x] multicodec: impl in JS
+- [x] multistream: protocol spec
+  - [x] multistream: impl in Go
+  - [x] multistream: impl in JS
+- [x] multibase / baseN: protocol spec
+  - [x] multibase / baseN: impl in Go
+  - [x] multibase / baseN: impl in JS
+
+
+### libp2p Protocols
+
+The libp2p protocols are the protocol stack for the modular p2p protocols library spun out of IPFS. These form a p2p-first network stack, with no assumptions, self description, and modular interfaces. More at https://github.com/ipfs/specs/tree/master/libp2p
+
+Consult [libp2p Requirements here](https://github.com/libp2p/libp2p/blob/master/REQUIREMENTS.md)
+
+### Bitswap
+
+Bitswap is the exchange protocol of IPFS. It simulates a data market.
+
+- [x] Bitswap: Protocol and architecture design
+  - [x] Bitswap: protocol spec
+  - [x] Bitswap: decision engine
+  - [x] Bitswap: strategy: altruist
+  - [x] Bitswap: strategy: logistic
+  - [x] Bitswap: strategy: programmable
+  - [x] Bitswap: support for keys
+  - [x] Bitswap: support for paths
+  - [ ] Bitswap: support for selectors
+  - [ ] Bitswap: hooks for other txns
+- [x] Bitswap: impl in Go
+  - [x] Bitswap: testing simulator
+  - [x] Bitswap: basic exchange
+  - [x] Bitswap: bandwidth accounting
+  - [x] Bitswap: decision engine
+  - [x] Bitswap: strategy: altruist
+  - [ ] Bitswap: strategy: logistic
+  - [ ] Bitswap: strategy: programmable
+  - [x] Bitswap: support for keys
+  - [ ] Bitswap: support for paths
+  - [ ] Bitswap: support for selectors
+  - [ ] Bitswap: hooks for other txns
+- [x] Bitswap: impl in JS
+  - [x] Bitswap: testing simulator
+  - [x] Bitswap: basic exchange
+  - [x] Bitswap: bandwidth accounting
+  - [x] Bitswap: decision engine
+  - [x] Bitswap: strategy: altruist
+  - [ ] Bitswap: strategy: logistic
+  - [x] Bitswap: strategy: programmable
+  - [x] Bitswap: support for keys
+  - [ ] Bitswap: support for paths
+  - [ ] Bitswap: support for selectors
+  - [ ] Bitswap: hooks for other txns
+- [x] Bitswap: bssim network simulations
+  - [x] Bitswap: bssim: basic in-proc simulation
+  - [x] Bitswap: bssim: basic multiproc simulation
+  - [ ] Bitswap: bssim: basic multi machine simulation
+  - [x] Bitswap: bssim: metrics collection
+  - [x] Bitswap: bssim: reporting
+  - [x] Bitswap: bssim: pluggable strategies
+  - [ ] Bitswap: bssim: strategies config
+
+### IPFS DHT
+
+The IPFS DHT is (today) a Kademlia based DHT implementing several libp2p protocols: Peer Discovery, Peer Routing, Content Routing, and some NAT Traversal assistance.
+
+- [x] IPFS DHT: Protocol and architecture design
+  - [x] IPFS DHT: protocol spec / messages
+  - [x] IPFS DHT: kad queries
+  - [x] IPFS DHT: kbucketing
+  - [x] IPFS DHT: churn resistance
+  - [ ] IPFS DHT: censor resistance
+- [x] IPFS DHT: impl in Go
+  - [x] IPFS DHT: messages
+  - [x] IPFS DHT: kad queries
+  - [x] IPFS DHT: kbucketing
+  - [x] IPFS DHT: churn resistance
+  - [ ] IPFS DHT: censor resistance
+- [x] IPFS DHT: impl in JS
+  - [x] IPFS DHT: messages
+  - [x] IPFS DHT: kad queries
+  - [x] IPFS DHT: kbucketing
+  - [x] IPFS DHT: churn resistance
+  - [ ] IPFS DHT: censor resistance
+- [x] IPFS DHT: dhtHell simulations
+  - [x] IPFS DHT: dhtHell programmable config
+  - [x] IPFS DHT: dhtHell in-proc tests
+  - [ ] IPFS DHT: dhtHell multi-proc tests
+  - [ ] IPFS DHT: dhtHell multi-machine tests
+  - [x] IPFS DHT: dhtHell 1,000 nodes
+  - [x] IPFS DHT: dhtHell 10,000 nodes
+  - [ ] IPFS DHT: dhtHell 100,000 nodes
+  - [ ] IPFS DHT: dhtHell 1,000,000 nodes
+
+
+### IPFS pub/sub
+
+The IPFS pub/sub service will provide fast delivery and routing for subnets of ipfs nodes. This is critical for dynamic applications. pub/sub (or multicast) will implement: Peer Discovery, Peer Routing, Content Routing, and some NAT Traversal assistance. It fulfills similar roles as the IPFS DHT, but with drastically different performance, security, and scalability guarantees. IPFS Pub/Sub is currently in development.
+
+- [ ] IPFS pub/sub: Protocol and architecture design
+  - [ ] IPFS pub/sub: protocol spec / messages
+  - [ ] IPFS pub/sub: record spec
+  - [x] IPFS pub/sub: one-hop support
+  - [ ] IPFS pub/sub: multihop tree forming
+  - [ ] IPFS pub/sub: churn resistance
+  - [ ] IPFS pub/sub: censor resistance
+  - [ ] IPFS pub/sub: topic/channel support
+  - [ ] IPFS pub/sub: hierarchical topic/channel support
+  - [ ] IPFS pub/sub: authenticated subnets
+  - [ ] IPFS pub/sub: private subnets (symmetric)
+  - [ ] IPFS pub/sub: private subnets (PKI)
+- [ ] IPFS pub/sub: impl in Go
+  - [x] IPFS pub/sub: prototyping in Go
+- [ ] IPFS pub/sub: impl in JS
+  - [x] IPFS pub/sub: prototyping in JS
+- [ ] IPFS pub/sub: pssim simulations
+  - [ ] IPFS pub/sub: pssim programmable config
+  - [ ] IPFS pub/sub: pssim in-proc tests
+  - [ ] IPFS pub/sub: pssim multi-proc tests
+  - [ ] IPFS pub/sub: pssim multi-machine tests
+  - [ ] IPFS pub/sub: pssim 1,000 nodes
+  - [ ] IPFS pub/sub: pssim 10,000 nodes
+  - [ ] IPFS pub/sub: pssim 100,000 nodes
+  - [ ] IPFS pub/sub: pssim 1,000,000 nodes
+
+### IPLD
+
+IPLD is the core format for data on IPFS. More at https://github.com/ipfs/specs/tree/master/ipld
+
+- [x] ipld v0 protobuf: spec
+  - [x] ipld v0 protobuf: impl in go
+  - [x] ipld v0 protobuf: impl in js
+- [x] ipld: spec
+  - [x] ipld: Linking
+  - [x] ipld: Pathing
+  - [ ] ipld: Selector
+  - [ ] ipld: Query
+  - [x] ipld: v0 compat
+  - [x] ipld: cbor serialization
+  - [x] ipld: links and resolving
+  - [x] ipld: streaming support
+- [x] ipld: impl in Go
+  - [x] ipld: Linking
+  - [x] ipld: Pathing
+  - [ ] ipld: Selector
+  - [ ] ipld: Query
+  - [x] ipld: v0 compat
+  - [x] ipld: cbor serialization
+  - [x] ipld: links and resolving
+  - [x] ipld: streaming support
+- [x] ipld: impl in JS
+  - [x] ipld: Linking
+  - [x] ipld: Pathing
+  - [ ] ipld: Selector
+  - [ ] ipld: Query
+  - [x] ipld: v0 compat
+  - [x] ipld: cbor serialization
+  - [x] ipld: links and resolving
+  - [ ] ipld: streaming support
+- [ ] ipld: website
+  - [ ] ipld: website: front page
+  - [ ] ipld: website: spec
+  - [ ] ipld: website: about
+  - [ ] ipld: website: playground
+    - [ ] ipld: website: playground spec
+    - [ ] ipld: website: playground impl
+
+### IPLD Data Structures and Importers
+
+IPLD data structures and importers are various data structures and programs that covert data or files from other native representations to and from IPLD graphs. Think of these as both the graph representation datastructs, and conversion codecs.
+
+- [x] unixfs for unix/posix files
+  - [x] unixfs spec
+    - [x] unixfs file
+    - [x] unixfs file sharding
+    - [x] unixfs file trickledag
+    - [x] unixfs dir
+    - [ ] unixfs dir sharding
+    - [x] unixfs metadata
+  - [x] unixfs impl in Go
+    - [x] unixfs file
+    - [x] unixfs file sharding
+    - [x] unixfs file trickledag
+    - [x] unixfs dir
+    - [x] unixfs dir sharding
+    - [x] unixfs metadata
+  - [x] unixfs impl in JS
+    - [x] unixfs file
+    - [x] unixfs file sharding
+    - [x] unixfs file trickledag
+    - [x] unixfs dir
+    - [x] unixfs dir sharding
+    - [x] unixfs metadata
+- [x] archives spec
+  - [x] tar
+  - [ ] zip
+  - [ ] rar
+- [ ] keychain spec
+  - [ ] keychain: keys
+  - [ ] keychain: sigs
+  - [ ] keychain: caps
+  - [ ] keychain: proofs
+
+### IPFS Repo
+
+More at https://github.com/ipfs/specs and  https://github.com/ipfs/fs-repo-migrations
+
+- [x] IPFS repo spec
+  - [x] IPFS repo impl in Go
+  - [x] IPFS repo impl in JS node
+  - [x] IPFS repo impl in JS browser
+- [x] IPFS fs-repo spec
+  - [x] IPFS fs-repo v0
+    - [x] IPFS fs-repo datastore (blocks and metadata)
+    - [x] IPFS fs-repo config file
+    - [x] IPFS fs-repo lock file
+    - [x] IPFS fs-repo logs dir
+  - [x] IPFS fs-repo v1
+    - [x] IPFS fs-repo version file
+    - [x] IPFS fs-repo api file
+    - [x] IPFS fs-repo blocks (data)
+    - [x] IPFS fs-repo datastore (metadata)
+  - [x] IPFS fs-repo v2
+    - [x] IPFS fs-repo ipld pinset
+  - [x] IPFS fs-repo impl in Go
+  - [x] IPFS fs-repo impl in JS node
+  - [x] IPFS fs-repo impl in JS browser
+  - [x] IPFS fs-repo-migrations
+    - [x] IPFS fs-repo-migrations 0-to-1
+    - [x] IPFS fs-repo-migrations 1-to-2
+    - [x] IPFS fs-repo-migrations 2-to-3
+
+### IPFS Protocol and Architecture
+
+- [x] IPFS architecture: macro protocol architecture
+- [x] IPFS architecture: futureproofing and self-description (multis)
+- [x] IPFS architecture: networking
+  - [x] IPFS architecture: encrypted and authenticated connectivity
+  - [x] IPFS architecture: peer and content routing
+  - [x] IPFS architecture: NAT traversal
+  - [x] IPFS architecture: line and pkt switching relay
+  - [x] IPFS architecture: abstracting and extracting libp2p
+  - [x] IPFS architecture: basic private networks (symmetric encryption)
+  - [ ] IPFS architecture: advanced private networks (PKI)
+- [x] IPFS architecture: merkle-linked graph and IPLD
+  - [x] IPFS architecture: pathing model for fs and web
+  - [x] IPFS architecture: selectors for graph traversals
+- [x] IPFS architecture: addressing
+  - [x] IPFS architecture: content addressing and resolution
+  - [x] IPFS architecture: key addressing and resolution
+  - [x] IPFS architecture: other resolver addressing and resolution
+- [x] IPFS architecture: node data sync model
+  - [x] IPFS architecture: ref pull resolution and retrieval
+  - [ ] IPFS architecture: ref push
+  - [x] IPFS architecture: ref pinning
+  - [ ] IPFS architecture: peer-to-peer RPC auth
+- [x] IPFS architecture: projection of protocol to programs
+  - [x] IPFS architecture: program model
+  - [x] IPFS architecture: service design
+  - [x] IPFS architecture: tool design
+  - [x] IPFS architecture: core api design
+    - [x] IPFS architecture: cli api design
+    - [x] IPFS architecture: http api design
+    - [ ] IPFS architecture: RPC api design
+- [x] IPFS architecture: distribution of programs
+- [x] IPFS architecture: webui design
+- [x] IPFS architecture: app designs
+- [ ] IPFS architecture: programmable policy hooks
+  - [ ] IPFS architecture: bitswap strategies and trading
+  - [ ] IPFS architecture: data advertising and serving
+  - [ ] IPFS architecture: social network
+  - [x] IPFS architecture: blocklists design
+    - [ ] IPFS architecture: blocklist support in gateway
+    - [ ] IPFS architecture: blocklist support in net
+    - [ ] IPFS architecture: scalable blocklist (bloom)
+- [ ] IPFS architecture: clustering
+  - [ ] IPFS architecture: cluster RAID/RAIN modes
+  - [ ] IPFS architecture: cluster consensus
+
+### Go implementation of IPFS
+
+The go-ipfs effort is the Go implementation of IPFS. It is meant to run as a commandline tool, as a background service, as a programmatic embedded node, through an RPC API, and to be used as part of other tools. go-ipfs is the reference implementation of IPFS. It includes the HTTP-to-IPFS Gateway implementation. More at https://github.com/ipfs/go-ipfs
+
+
+- [x] go-ipfs ipfs node components
+  - [x] go-ipfs multi protocols
+  - [x] go-ipfs component: repo
+  - [x] go-ipfs component: networking (libp2p)
+  - [x] go-ipfs component: bitswap
+  - [x] go-ipfs component: dag / ipld
+  - [x] go-ipfs component: pinning
+  - [x] go-ipfs component: block api
+  - [x] go-ipfs component: object api
+  - [x] go-ipfs component: files api
+  - [x] go-ipfs component: daemon
+  - [x] go-ipfs component: data importing
+  - [x] go-ipfs component: gateway
+  - [x] go-ipfs component: http api
+- [x] go-ipfs ipfs node api
+  - [x] go-ipfs core api impl
+    - [x] go-ipfs core api: version
+    - [x] go-ipfs core api: daemon
+    - [x] go-ipfs core api: id
+    - [x] go-ipfs core api: block
+    - [x] go-ipfs core api: object
+    - [x] go-ipfs core api: refs
+    - [x] go-ipfs core api: repo
+    - [x] go-ipfs core api: pin
+    - [x] go-ipfs core api: log
+  - [x] go-ipfs ext api impl
+    - [x] go-ipfs ext api: name (ipns)
+    - [x] go-ipfs ext api: dns
+    - [x] go-ipfs ext api: tar
+    - [ ] go-ipfs ext api: tour
+    - [x] go-ipfs ext api: files
+    - [x] go-ipfs ext api: stat
+    - [x] go-ipfs ext api: mount
+    - [x] go-ipfs ext api: bootstrap
+    - [x] go-ipfs ext api: bitswap
+  - [x] go-ipfs tool api impl
+    - [x] go-ipfs tool api: init
+    - [x] go-ipfs tool api: config
+    - [x] go-ipfs tool api: update
+    - [x] go-ipfs tool api: commands
+  - [x] go-ipfs net api impl
+    - [x] go-ipfs net api: ping
+    - [x] go-ipfs net api: dht
+    - [x] go-ipfs net api: swarm
+    - [ ] go-ipfs net api: records
+- [x] go-ipfs cli api impl
+  - [x] go-ipfs cli codecs
+- [x] go-ipfs http api impl
+  - [x] go-ipfs http api: streaming
+  - [x] go-ipfs http api: multipart
+
+### Javascript implementation of IPFS
+
+The js-ipfs effort is the javascript implementation of IPFS. It is meant to run on both node.js and today's regular web browsers. It is close, but not yet ready. More at https://github.com/ipfs/js-ipfs
+
+- [x] js-ipfs ipfs node components
+  - [x] js-ipfs multi protocols
+  - [x] js-ipfs component: repo
+  - [x] js-ipfs component: networking (libp2p)
+  - [x] js-ipfs component: bitswap
+  - [x] js-ipfs component: dag / ipld
+  - [x] js-ipfs component: pinning
+  - [x] js-ipfs component: block api
+  - [x] js-ipfs component: object api
+  - [x] js-ipfs component: files api
+  - [x] js-ipfs component: daemon
+  - [x] js-ipfs component: data importing
+  - [x] js-ipfs component: http api
+- [ ] js-ipfs ipfs node api
+  - [x] js-ipfs core api impl
+    - [x] js-ipfs core api: version
+    - [x] js-ipfs core api: daemon
+    - [x] js-ipfs core api: id
+    - [x] js-ipfs core api: block
+    - [x] js-ipfs core api: object
+    - [ ] js-ipfs core api: refs
+    - [x] js-ipfs core api: repo
+    - [x] js-ipfs core api: pin
+    - [ ] js-ipfs core api: log
+  - [ ] js-ipfs ext api impl
+    - [ ] js-ipfs ext api: name (ipns)
+    - [ ] js-ipfs ext api: dns
+    - [ ] js-ipfs ext api: tar
+    - [x] js-ipfs ext api: files
+    - [ ] js-ipfs ext api: stat
+    - [ ] js-ipfs ext api: mount
+    - [x] js-ipfs ext api: bootstrap
+    - [x] js-ipfs ext api: bitswap
+  - [x] js-ipfs tool api impl
+    - [x] js-ipfs tool api: init
+    - [x] js-ipfs tool api: config
+    - [ ] js-ipfs tool api: update
+    - [x] js-ipfs tool api: commands
+  - [ ] js-ipfs net api impl
+    - [x] js-ipfs net api: ping
+    - [ ] js-ipfs net api: dht
+    - [x] js-ipfs net api: swarm
+    - [ ] js-ipfs net api: records
+- [x] js-ipfs cli api impl
+- [x] js-ipfs http api impl
+  - [x] js-ipfs http api: streaming
+  - [x] js-ipfs http api: multipart
+
+### IPFS directly on the Browsers
+
+As a protocol for the web, the ultimate goal of IPFS is to run directly in the browsers. We are achieving this through a four-step plan:
+
+- (1) Implement IPFS in any language, and use a js-ipfs-api library to delegate commands to an IPFS API (e.g. go-ipfs running on localhost). This already works today, and many applications already exist leveraging IPFS in the browser this way.
+- (2) Implement IPFS in javascript, and use js-ipfs directly in the browser tab. This is in progress today.
+- (3) Build browser extensions that use IPFS to serve IPFS URIs and expose ipfs to the browser tab. This can be done using go-ipfs (API on localhost) or ideally a bundled js-ipfs. This is in progress today. The firefox extension already has 400+ daily users.
+- (4) Finally, submit patches to the major browsers adding IPFS support.
+
+We have finished step (1). We are currently working on steps (2) and (3). Step (4) is likely a 2017 endeavor.
+
+- [x] IPFS API used in a browser tab
+  - [x] go-ipfs implementation
+  - [x] js-ipfs-api client library
+  - [x] use background go-ipfs node (localhost or elsewhere)
+- [x] IPFS protocol running in a browser tab, in js
+  - [x] js-libp2p implementation
+  - [x] js-ipfs implementation
+  - [x] libp2p.js browser library
+  - [x] ipfs.js browser library
+- [x] IPFS running with a browser extension
+  - [x] go-ipfs implementation
+  - [x] js-ipfs implementation
+  - [x] firefox extension
+    - [x] use background go-ipfs node
+    - [ ] easy install of go-ipfs node
+    - [x] bundling of js-ipfs node
+    - [x] url rewriting
+    - [x] node management
+    - [x] api configuration
+    - [ ] simple UX for users
+    - [ ] expose ipfs and p2p in the browser window
+  - [x] chrome extension
+    - [x] use background go-ipfs node
+    - [ ] easy install of go-ipfs node
+    - [x] bundling of js-ipfs node
+    - [x] url rewriting
+    - [ ] node management
+    - [ ] api configuration
+    - [ ] simple UX for users
+    - [x] expose ipfs and p2p in the browser window
+- [ ] IPFS running natively in a browser
+  - [x] go-ipfs implementation (for chrome or firefox)
+    - [ ] go-ipfs static lib (for chrome or firefox)
+  - [x] js-ipfs implementation (for chrome or firefox)
+  - [ ] rust-ipfs implementation (for servo)
+  - [ ] chromium patches adding IPFS support
+  - [ ] firefox patches adding IPFS support
+  - [ ] servo patches adding IPFS support
+  - [ ] safari patches adding IPFS support
+
+
+### IPFS Node Management Console (webui)
+
+We have an ipfs node "management console" GUI, delivered as a distributed webapp (dapp). This shows information about an ipfs node, and allows issuing some commands. The webui is entirely hosted and distributed through IPFS itself, demonstrating dynamic web applications on IPFS. More at https://github.com/ipfs/webui
+
+- [x] webui console architecture
+  - [x] R/W privileged API route (:5001)
+    - [x] Security: Origin and CORS
+    - [x] Security: exposed only locally
+    - [ ] Security: token based access
+  - [x] distributed through IPFS itself
+  - [x] accessed through http-to-ipfs gateway
+- [x] webui console v0
+  - [x] webapp design
+  - [x] basic node info
+  - [x] peer map (3D earth)
+  - [x] ipfs dag explorer
+  - [x] ipfs file viewer
+    - [x] listing all files
+    - [x] adding files (+ drag and drop)
+  - [x] tail logs (json)
+  - [x] view & edit config (json)
+- [x] webui console v1
+  - [x] webapp redesign
+  - [x] peer map (flat and 3D)
+  - [x] new dag explorer
+  - [x] new file explorer
+    - [x] file navigation
+    - [x] drag and drop support
+    - [x] file previews
+
+
+### HTTP to IPFS Gateway
+
+In order to ease the adoption and deployment of IPFS, we have HTTP-to-IPFS Gateways. This means two related things: (a) implementation of an HTTP-to-IPFS gateway server (currently part of go-ipfs), and (b) a globally accessible service Protocol Labs runs for the community. All of the official IPFS websites are now self-hosted directly on IPFS.
+
+- [x] HTTP Gateway implementation (in go-ipfs)
+  - [x] HTTP Gateway file listing
+  - [x] HTTP Gateway /ipfs route for files
+  - [x] HTTP Gateway /ipns route for names
+  - [ ] HTTP Gateway /ipfs POST writes
+  - [ ] HTTP Gateway /ipns PUT/POST writes
+  - [x] HTTP Gateway CORS and Headers support
+- [x] HTTP Gateway Service (ipfs.io)
+  - [x] HTTP Gateway Service: solarnet vps infrastructure
+  - [x] HTTP Gateway Service: DNS architecture
+    - [x] HTTP Gateway Service DNS: deployed at ipfs.io
+    - [x] HTTP Gateway Service DNS: dnslink, CNAME, A support
+    - [ ] HTTP Gateway Service DNS: zone automation
+    - [ ] HTTP Gateway Service DNS: TLD redundancy
+  - [x] HTTP Gateway Service: nginx frontend
+    - [x] HTTP Gateway Service: backend fallbacks
+    - [x] HTTP Gateway Service: nginx blocklists (dmca)
+    - [ ] HTTP Gateway Service: rate limiting
+  - [x] HTTP Gateway Service Devops
+    - [x] HTTP Gateway Service Devops: containers
+    - [x] HTTP Gateway Service Devops: automated deployments
+    - [x] HTTP Gateway Service Devops: logging
+    - [x] HTTP Gateway Service Devops: event monitoring
+    - [x] HTTP Gateway Service Devops: status alerts
+    - [ ] HTTP Gateway Service Devops: status webpage (status.ipfs.io)
+    - [ ] HTTP Gateway Service Devops: chaos monkey
+- [x] HTTP Gateway Self-hosting
+  - [x] HTTP Gateway Self-hosting: ipfs.io project website
+  - [x] HTTP Gateway Self-hosting: dist.ipfs.io
+  - [x] HTTP Gateway Self-hosting: blog.ipfs.io
+  - [x] HTTP Gateway Self-hosting: refs.ipfs.io
+
+### IPFS Distributions
+
+IPFS Distributions is the distribution model for IPFS Project programs. This means a repository of pages, source, binaries, and links for all programs officially distributed by the project.
+
+- [x] IPFS Distributions: architecture
+- [ ] IPFS Distributions: security
+  - [x] IPFS Distributions: TLS cert for HTTP site
+  - [ ] IPFS Distributions: code signing
+    - [x] IPFS Distributions: code signing source
+    - [x] IPFS Distributions: code signing protocol
+    - [x] IPFS Distributions: code signing team yubikeys
+- [x] IPFS Distributions: website
+  - [x] IPFS Distributions: website design
+  - [x] IPFS Distributions: website landing page
+  - [x] IPFS Distributions: website program listings
+  - [x] IPFS Distributions: website domain (dist.ipfs.io)
+  - [ ] IPFS Distributions: website localization
+- [x] IPFS Distributions: tools
+  - [x] IPFS Distributions: go-ipfs
+  - [x] IPFS Distributions: ipfs-update
+  - [x] IPFS Distributions: ipget
+  - [x] IPFS Distributions: fs-repo-migrations
+  - [x] IPFS Distributions: gx, gx-go
+  - [ ] IPFS Distributions: station
+  - [ ] IPFS Distributions: webui
+
+### Security
+
+- [ ] Create a bug bounty program for IPFS
+- [ ] Have IPFS go and js implementations be fully Audited
+- [ ] Create a Security Working Group
+- [ ] Create a responsible disclosure program
+
+### IPFS Blog and Newsletter
+
+In order to keep the community updated, we run a blog. This blog is distributed through IPFS itself, and through an email newsletter.
+
+- [x] ipfs blog
+  - [x] blog design
+  - [x] distribute through ipfs
+  - [x] blog.ipfs.io domain
+  - [ ] use POST datastructure
+- [x] weekly/newsletter
+  - [x] establish newsletter process
+  - [x] highlight contributions and contributors
+  - [x] post to the blog
+- [x] email subscription
+  - [x] use tinyletter
+  - [x] post weekly
+  - [ ] post blog

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -738,7 +738,7 @@ In order to ease the adoption and deployment of IPFS, we have HTTP-to-IPFS gatew
   - [x] HTTP gateway self-hosting: blog.ipfs.io
   - [x] HTTP gateway self-hosting: refs.ipfs.io
 
-### IPFS distributions
+## IPFS distributions
 
 "IPFS distributions" means the distribution model for IPFS project programs. This means a repository of pages, source, binaries, and links for all programs officially distributed by the project.
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -1,11 +1,11 @@
 ---
-title: IPFS project requirements to 1.0.0
+title: Roadmap
 description: Learn about the milestones in the IPFS project in order to reach version 1.0.0.
 ---
 
-# IPFS Project Requirements to 1.0.0
+# Roadmap: IPFS project requirements to 1.0.0
 
-## Description
+## Summary
 
 In order for IPFS to reach its maturity state, going from Alpha, to Beta and to v1.0.0, the project will need:
 
@@ -15,20 +15,18 @@ In order for IPFS to reach its maturity state, going from Alpha, to Beta and to 
 - A third party implementation of IPFS, fully interoperable with the go and JavaScript versions.
 - A release plan and cycle, including a strategy to support specific key releases for longer periods of time (i.e LTS releases vs stable)
 
-## Milestones
+Here you will find a comprehensive list of the various challenges and milestones in the IPFS project to reach version 1.0.0. They are not ordered in any way at the moment, merely grouped.
 
-Here you will find a comprehensive list of the various challenges and milestones in the IPFS Project to reach version 1.0.0. They are not ordered in any way at the moment, merely grouped.
-
-### Sustainability and Governance
+## Sustainability and governance
 
 These are some of the milestones to hit to create a active, sustainable, inclusive and participatory governance model for IPFS.
 
-- [x] Organize IPFS All Hands.
-- [ ] Have IPFS lead by a Steering Working Group.
-- [ ] Define several Working Groups focused on different parts of the project (e.g Community Engagement, Documentation and Education, IPFS in Web Browsers).
-- [ ] Define a release plan and long term support plan.
+- [x] Organize IPFS all-hands.
+- [ ] Have IPFS lead by a steering working group.
+- [x] Define several working groups focused on different parts of the project (e.g community engagement, documentation and education, IPFS in web browsers).
+- [ ] Define a release plan and long-term support plan.
 
-### IPFS Use Cases
+## IPFS use cases
 
 These are some use case milestones to drive development.
 
@@ -62,9 +60,9 @@ These are some use case milestones to drive development.
   - [x] Support for HTTP API usage
   - [ ] Support for unix sockets RPC API usage
   - [x] Support for embedded, programmatic API usage
-  - [x] Support for HTTP Gateway
+  - [x] Support for HTTP gateway
 
-### Performance Milestones
+## Performance milestones
 
 These are some basic performance milestones to hit.
 
@@ -97,7 +95,7 @@ These are some basic performance milestones to hit.
   - [ ] Good enough for the entire web - EB
   - [ ] Good enough for top10 websites - EB
 
-### Developer Libraries
+## Developer libraries
 
 These are some libraries that must exist to make developers' lives easy. It is critical that making fully dynamic apps on IPFS should be just as easy or easier than traditional systems.
 
@@ -139,7 +137,7 @@ These are some libraries that must exist to make developers' lives easy. It is c
   - [ ] POST datastructure
   - [ ] decentralized identity
 
-### Security Milestones
+## Security milestones
 
 - [ ] Network security
   - [x] upgradable transport encryption (multistream)
@@ -172,7 +170,7 @@ These are some libraries that must exist to make developers' lives easy. It is c
   - [ ] Audit: 3x independent professional security audits of full protocol
   - [ ] Audit: 3x independent professional security audits of implementations
 
-### Network Scalability
+## Network scalability
 
 The scalability of the IPFS protocol depends on careful design of algorithms and models, careful optimization of our implementations, and careful attention to the security properties of the protocols. Reaching high scalability for self-organizing peer-to-peer protocols is HARD, though definitely achievable. We measure scalability in orders of magnitude, as larger thresholds will require revisiting various parts of our codebase.
 
@@ -199,9 +197,9 @@ Our scalability observations are divided into simulations, real network tests, a
   - [ ] Scalability to 1,000,000s of nodes
   - [ ] Scalability to 1,000,000,000s of nodes
 
-### Polish level
+## Polish level
 
-The polish level achieved defined how much effort has gone into polishing all the corners of the tools, APIs, documentation, and so on. Early on, things will be much more rough as we need to focus on implementation speed over final polish. As we reach completion of the implementations, we turn our focus towards scalability, stability, and security. After that, we focus on end user polish.
+The polish level achieved defines how much effort has gone into polishing all the corners of the tools, APIs, documentation, and so on. Early on, things will be much more rough as we need to focus on implementation speed over final polish. As we reach completion of the implementations, we turn our focus towards scalability, stability, and security. After that, we focus on end-user polish.
 
 - [x] Polish level: alpha - individuals innovators
 - [x] Polish level: alpha - production for early adopters
@@ -210,9 +208,9 @@ The polish level achieved defined how much effort has gone into polishing all th
 - [ ] Polish level: 1.0 - production for all
 
 
-### Multiformats
+## Multiformats
 
-The multiformats are a set of self-describing protocols/formats for future-proofed or "upgradable systems" (systems that make no silly assumptions that are likely to break over time).
+Multiformats are a set of self-describing protocols/formats for future-proofed or "upgradable systems" (systems that make no assumptions that are likely to break over time).
 
 - [x] multiaddr: protocol design
   - [x] multiaddr: impl in Go
@@ -244,13 +242,13 @@ The multiformats are a set of self-describing protocols/formats for future-proof
   - [x] multibase / baseN: impl in JS
 
 
-### libp2p Protocols
+## libp2p protocols
 
 The libp2p protocols are the protocol stack for the modular p2p protocols library spun out of IPFS. These form a p2p-first network stack, with no assumptions, self description, and modular interfaces. More at https://github.com/ipfs/specs/tree/master/libp2p
 
-Consult [libp2p Requirements here](https://github.com/libp2p/libp2p/blob/master/REQUIREMENTS.md)
+Consult [libp2p requirements here](https://github.com/libp2p/libp2p/blob/master/REQUIREMENTS.md)
 
-### Bitswap
+## Bitswap
 
 Bitswap is the exchange protocol of IPFS. It simulates a data market.
 
@@ -297,9 +295,9 @@ Bitswap is the exchange protocol of IPFS. It simulates a data market.
   - [x] Bitswap: bssim: pluggable strategies
   - [ ] Bitswap: bssim: strategies config
 
-### IPFS DHT
+## IPFS DHT
 
-The IPFS DHT is (today) a Kademlia based DHT implementing several libp2p protocols: Peer Discovery, Peer Routing, Content Routing, and some NAT Traversal assistance.
+The IPFS DHT is (today) a Kademlia based DHT implementing several libp2p protocols: peer discovery, peer routing, content routing, and some NAT traversal assistance.
 
 - [x] IPFS DHT: Protocol and architecture design
   - [x] IPFS DHT: protocol spec / messages
@@ -330,7 +328,7 @@ The IPFS DHT is (today) a Kademlia based DHT implementing several libp2p protoco
   - [ ] IPFS DHT: dhtHell 1,000,000 nodes
 
 
-### IPFS pub/sub
+## IPFS pub/sub
 
 The IPFS pub/sub service will provide fast delivery and routing for subnets of ipfs nodes. This is critical for dynamic applications. pub/sub (or multicast) will implement: Peer Discovery, Peer Routing, Content Routing, and some NAT Traversal assistance. It fulfills similar roles as the IPFS DHT, but with drastically different performance, security, and scalability guarantees. IPFS Pub/Sub is currently in development.
 
@@ -360,7 +358,7 @@ The IPFS pub/sub service will provide fast delivery and routing for subnets of i
   - [ ] IPFS pub/sub: pssim 100,000 nodes
   - [ ] IPFS pub/sub: pssim 1,000,000 nodes
 
-### IPLD
+## IPLD
 
 IPLD is the core format for data on IPFS. More at https://github.com/ipfs/specs/tree/master/ipld
 
@@ -402,7 +400,7 @@ IPLD is the core format for data on IPFS. More at https://github.com/ipfs/specs/
     - [ ] ipld: website: playground spec
     - [ ] ipld: website: playground impl
 
-### IPLD Data Structures and Importers
+## IPLD data structures and importers
 
 IPLD data structures and importers are various data structures and programs that covert data or files from other native representations to and from IPLD graphs. Think of these as both the graph representation datastructs, and conversion codecs.
 
@@ -438,7 +436,7 @@ IPLD data structures and importers are various data structures and programs that
   - [ ] keychain: caps
   - [ ] keychain: proofs
 
-### IPFS Repo
+## IPFS repo
 
 More at https://github.com/ipfs/specs and  https://github.com/ipfs/fs-repo-migrations
 
@@ -467,7 +465,7 @@ More at https://github.com/ipfs/specs and  https://github.com/ipfs/fs-repo-migra
     - [x] IPFS fs-repo-migrations 1-to-2
     - [x] IPFS fs-repo-migrations 2-to-3
 
-### IPFS Protocol and Architecture
+## IPFS protocol and architecture
 
 - [x] IPFS architecture: macro protocol architecture
 - [x] IPFS architecture: futureproofing and self-description (multis)
@@ -495,12 +493,12 @@ More at https://github.com/ipfs/specs and  https://github.com/ipfs/fs-repo-migra
   - [x] IPFS architecture: program model
   - [x] IPFS architecture: service design
   - [x] IPFS architecture: tool design
-  - [x] IPFS architecture: core api design
-    - [x] IPFS architecture: cli api design
-    - [x] IPFS architecture: http api design
-    - [ ] IPFS architecture: RPC api design
+  - [x] IPFS architecture: core API design
+    - [x] IPFS architecture: CLI API design
+    - [x] IPFS architecture: HTTP API design
+    - [ ] IPFS architecture: RPC API design
 - [x] IPFS architecture: distribution of programs
-- [x] IPFS architecture: webui design
+- [x] IPFS architecture: WebUI design
 - [x] IPFS architecture: app designs
 - [ ] IPFS architecture: programmable policy hooks
   - [ ] IPFS architecture: bitswap strategies and trading
@@ -514,10 +512,9 @@ More at https://github.com/ipfs/specs and  https://github.com/ipfs/fs-repo-migra
   - [ ] IPFS architecture: cluster RAID/RAIN modes
   - [ ] IPFS architecture: cluster consensus
 
-### Go implementation of IPFS
+## Go implementation of IPFS
 
-The go-ipfs effort is the Go implementation of IPFS. It is meant to run as a commandline tool, as a background service, as a programmatic embedded node, through an RPC API, and to be used as part of other tools. go-ipfs is the reference implementation of IPFS. It includes the HTTP-to-IPFS Gateway implementation. More at https://github.com/ipfs/go-ipfs
-
+The go-ipfs effort is the Go implementation of IPFS. It is meant to run as a command-line tool, as a background service, as a programmatic embedded node, through an RPC API, and to be used as part of other tools. go-ipfs is the reference implementation of IPFS. It includes the HTTP-to-IPFS gateway implementation. More at https://github.com/ipfs/go-ipfs
 
 - [x] go-ipfs ipfs node components
   - [x] go-ipfs multi protocols
@@ -570,23 +567,23 @@ The go-ipfs effort is the Go implementation of IPFS. It is meant to run as a com
   - [x] go-ipfs http api: streaming
   - [x] go-ipfs http api: multipart
 
-### Javascript implementation of IPFS
+## JavaScript implementation of IPFS
 
-The js-ipfs effort is the javascript implementation of IPFS. It is meant to run on both node.js and today's regular web browsers. It is close, but not yet ready. More at https://github.com/ipfs/js-ipfs
+The js-ipfs effort is the JavaScript implementation of IPFS. It is meant to run on both node.js and today's regular web browsers. More at https://github.com/ipfs/js-ipfs
 
 - [x] js-ipfs ipfs node components
   - [x] js-ipfs multi protocols
   - [x] js-ipfs component: repo
   - [x] js-ipfs component: networking (libp2p)
   - [x] js-ipfs component: bitswap
-  - [x] js-ipfs component: dag / ipld
+  - [x] js-ipfs component: dag/IPLD
   - [x] js-ipfs component: pinning
-  - [x] js-ipfs component: block api
-  - [x] js-ipfs component: object api
-  - [x] js-ipfs component: files api
+  - [x] js-ipfs component: block API
+  - [x] js-ipfs component: object API
+  - [x] js-ipfs component: files API
   - [x] js-ipfs component: daemon
   - [x] js-ipfs component: data importing
-  - [x] js-ipfs component: http api
+  - [x] js-ipfs component: http API
 - [ ] js-ipfs ipfs node api
   - [x] js-ipfs core api impl
     - [x] js-ipfs core api: version
@@ -622,22 +619,22 @@ The js-ipfs effort is the javascript implementation of IPFS. It is meant to run 
   - [x] js-ipfs http api: streaming
   - [x] js-ipfs http api: multipart
 
-### IPFS directly on the Browsers
+## IPFS directly in browsers
 
-As a protocol for the web, the ultimate goal of IPFS is to run directly in the browsers. We are achieving this through a four-step plan:
+As a protocol for the web, the ultimate goal of IPFS is to run directly in browsers. We are achieving this through a four-step plan:
 
 - (1) Implement IPFS in any language, and use a js-ipfs-api library to delegate commands to an IPFS API (e.g. go-ipfs running on localhost). This already works today, and many applications already exist leveraging IPFS in the browser this way.
 - (2) Implement IPFS in javascript, and use js-ipfs directly in the browser tab. This is in progress today.
 - (3) Build browser extensions that use IPFS to serve IPFS URIs and expose ipfs to the browser tab. This can be done using go-ipfs (API on localhost) or ideally a bundled js-ipfs. This is in progress today. The firefox extension already has 400+ daily users.
 - (4) Finally, submit patches to the major browsers adding IPFS support.
 
-We have finished step (1). We are currently working on steps (2) and (3). Step (4) is likely a 2017 endeavor.
+We have finished step (1). We are currently working on steps (2) and (3). 
 
 - [x] IPFS API used in a browser tab
   - [x] go-ipfs implementation
   - [x] js-ipfs-api client library
   - [x] use background go-ipfs node (localhost or elsewhere)
-- [x] IPFS protocol running in a browser tab, in js
+- [x] IPFS protocol running in a browser tab, in JS
   - [x] js-libp2p implementation
   - [x] js-ipfs implementation
   - [x] libp2p.js browser library
@@ -645,16 +642,16 @@ We have finished step (1). We are currently working on steps (2) and (3). Step (
 - [x] IPFS running with a browser extension
   - [x] go-ipfs implementation
   - [x] js-ipfs implementation
-  - [x] firefox extension
+  - [x] Firefox extension
     - [x] use background go-ipfs node
     - [ ] easy install of go-ipfs node
     - [x] bundling of js-ipfs node
-    - [x] url rewriting
+    - [x] URL rewriting
     - [x] node management
-    - [x] api configuration
+    - [x] API configuration
     - [ ] simple UX for users
-    - [ ] expose ipfs and p2p in the browser window
-  - [x] chrome extension
+    - [ ] expose IPFS and p2p in the browser window
+  - [x] Chrome extension
     - [x] use background go-ipfs node
     - [ ] easy install of go-ipfs node
     - [x] bundling of js-ipfs node
@@ -662,21 +659,21 @@ We have finished step (1). We are currently working on steps (2) and (3). Step (
     - [ ] node management
     - [ ] api configuration
     - [ ] simple UX for users
-    - [x] expose ipfs and p2p in the browser window
+    - [x] expose IPFS and p2p in the browser window
 - [ ] IPFS running natively in a browser
-  - [x] go-ipfs implementation (for chrome or firefox)
-    - [ ] go-ipfs static lib (for chrome or firefox)
-  - [x] js-ipfs implementation (for chrome or firefox)
-  - [ ] rust-ipfs implementation (for servo)
-  - [ ] chromium patches adding IPFS support
-  - [ ] firefox patches adding IPFS support
-  - [ ] servo patches adding IPFS support
-  - [ ] safari patches adding IPFS support
+  - [x] go-ipfs implementation (for Chrome or Firefox)
+    - [ ] go-ipfs static lib (for Chrome or Firefox)
+  - [x] js-ipfs implementation (for Chrome or Firefox)
+  - [ ] rust-ipfs implementation (for Servo)
+  - [ ] Chromium patches adding IPFS support
+  - [ ] Firefox patches adding IPFS support
+  - [ ] Servo patches adding IPFS support
+  - [ ] Safari patches adding IPFS support
 
 
-### IPFS Node Management Console (webui)
+## IPFS node management Console (WebUI)
 
-We have an ipfs node "management console" GUI, delivered as a distributed webapp (dapp). This shows information about an ipfs node, and allows issuing some commands. The webui is entirely hosted and distributed through IPFS itself, demonstrating dynamic web applications on IPFS. More at https://github.com/ipfs/webui
+We have an IPFS node "management console" GUI, delivered as a distributed webapp (dapp). This shows information about an IPFS node, and allows issuing some commands. The WebUI is entirely hosted and distributed through IPFS itself, demonstrating dynamic web applications on IPFS. More at https://github.com/ipfs/webui
 
 - [x] webui console architecture
   - [x] R/W privileged API route (:5001)
@@ -705,76 +702,76 @@ We have an ipfs node "management console" GUI, delivered as a distributed webapp
     - [x] file previews
 
 
-### HTTP to IPFS Gateway
+## HTTP-to-IPFS gateway
 
-In order to ease the adoption and deployment of IPFS, we have HTTP-to-IPFS Gateways. This means two related things: (a) implementation of an HTTP-to-IPFS gateway server (currently part of go-ipfs), and (b) a globally accessible service Protocol Labs runs for the community. All of the official IPFS websites are now self-hosted directly on IPFS.
+In order to ease the adoption and deployment of IPFS, we have HTTP-to-IPFS gateways. This means two related things: (a) implementation of an HTTP-to-IPFS gateway server (currently part of go-ipfs), and (b) a globally accessible service Protocol Labs runs for the community. All of the official IPFS websites are now self-hosted directly on IPFS.
 
-- [x] HTTP Gateway implementation (in go-ipfs)
-  - [x] HTTP Gateway file listing
-  - [x] HTTP Gateway /ipfs route for files
-  - [x] HTTP Gateway /ipns route for names
-  - [ ] HTTP Gateway /ipfs POST writes
-  - [ ] HTTP Gateway /ipns PUT/POST writes
-  - [x] HTTP Gateway CORS and Headers support
-- [x] HTTP Gateway Service (ipfs.io)
-  - [x] HTTP Gateway Service: solarnet vps infrastructure
-  - [x] HTTP Gateway Service: DNS architecture
-    - [x] HTTP Gateway Service DNS: deployed at ipfs.io
-    - [x] HTTP Gateway Service DNS: dnslink, CNAME, A support
-    - [ ] HTTP Gateway Service DNS: zone automation
-    - [ ] HTTP Gateway Service DNS: TLD redundancy
-  - [x] HTTP Gateway Service: nginx frontend
-    - [x] HTTP Gateway Service: backend fallbacks
-    - [x] HTTP Gateway Service: nginx blocklists (dmca)
-    - [ ] HTTP Gateway Service: rate limiting
-  - [x] HTTP Gateway Service Devops
-    - [x] HTTP Gateway Service Devops: containers
-    - [x] HTTP Gateway Service Devops: automated deployments
-    - [x] HTTP Gateway Service Devops: logging
-    - [x] HTTP Gateway Service Devops: event monitoring
-    - [x] HTTP Gateway Service Devops: status alerts
-    - [ ] HTTP Gateway Service Devops: status webpage (status.ipfs.io)
-    - [ ] HTTP Gateway Service Devops: chaos monkey
-- [x] HTTP Gateway Self-hosting
-  - [x] HTTP Gateway Self-hosting: ipfs.io project website
-  - [x] HTTP Gateway Self-hosting: dist.ipfs.io
-  - [x] HTTP Gateway Self-hosting: blog.ipfs.io
-  - [x] HTTP Gateway Self-hosting: refs.ipfs.io
+- [x] HTTP gateway implementation (in go-ipfs)
+  - [x] HTTP gateway file listing
+  - [x] HTTP gateway /ipfs route for files
+  - [x] HTTP gateway /ipns route for names
+  - [ ] HTTP gateway /ipfs POST writes
+  - [ ] HTTP gateway /ipns PUT/POST writes
+  - [x] HTTP gateway CORS and headers support
+- [x] HTTP gateway service (ipfs.io)
+  - [x] HTTP gateway service: solarnet vps infrastructure
+  - [x] HTTP gateway service: DNS architecture
+    - [x] HTTP gateway service DNS: deployed at ipfs.io
+    - [x] HTTP gateway service DNS: dnslink, CNAME, A support
+    - [ ] HTTP gateway service DNS: zone automation
+    - [ ] HTTP gateway service DNS: TLD redundancy
+  - [x] HTTP gateway service: nginx frontend
+    - [x] HTTP gateway service: backend fallbacks
+    - [x] HTTP gateway service: nginx blocklists (dmca)
+    - [ ] HTTP gateway service: rate limiting
+  - [x] HTTP gateway service devops
+    - [x] HTTP gateway service Devops: containers
+    - [x] HTTP gateway service Devops: automated deployments
+    - [x] HTTP gateway service Devops: logging
+    - [x] HTTP gateway service Devops: event monitoring
+    - [x] HTTP gateway service Devops: status alerts
+    - [ ] HTTP gateway service Devops: status webpage (status.ipfs.io)
+    - [ ] HTTP gateway service Devops: chaos monkey
+- [x] HTTP gateway self-hosting
+  - [x] HTTP gateway self-hosting: ipfs.io project website
+  - [x] HTTP gateway self-hosting: dist.ipfs.io
+  - [x] HTTP gateway self-hosting: blog.ipfs.io
+  - [x] HTTP gateway self-hosting: refs.ipfs.io
 
-### IPFS Distributions
+### IPFS distributions
 
-IPFS Distributions is the distribution model for IPFS Project programs. This means a repository of pages, source, binaries, and links for all programs officially distributed by the project.
+"IPFS distributions" means the distribution model for IPFS project programs. This means a repository of pages, source, binaries, and links for all programs officially distributed by the project.
 
-- [x] IPFS Distributions: architecture
-- [ ] IPFS Distributions: security
-  - [x] IPFS Distributions: TLS cert for HTTP site
-  - [ ] IPFS Distributions: code signing
-    - [x] IPFS Distributions: code signing source
-    - [x] IPFS Distributions: code signing protocol
-    - [x] IPFS Distributions: code signing team yubikeys
-- [x] IPFS Distributions: website
-  - [x] IPFS Distributions: website design
-  - [x] IPFS Distributions: website landing page
-  - [x] IPFS Distributions: website program listings
-  - [x] IPFS Distributions: website domain (dist.ipfs.io)
-  - [ ] IPFS Distributions: website localization
-- [x] IPFS Distributions: tools
-  - [x] IPFS Distributions: go-ipfs
-  - [x] IPFS Distributions: ipfs-update
-  - [x] IPFS Distributions: ipget
-  - [x] IPFS Distributions: fs-repo-migrations
-  - [x] IPFS Distributions: gx, gx-go
-  - [ ] IPFS Distributions: station
-  - [ ] IPFS Distributions: webui
+- [x] IPFS distributions: architecture
+- [ ] IPFS distributions: security
+  - [x] IPFS distributions: TLS cert for HTTP site
+  - [ ] IPFS distributions: code signing
+    - [x] IPFS distributions: code signing source
+    - [x] IPFS distributions: code signing protocol
+    - [x] IPFS distributions: code signing team yubikeys
+- [x] IPFS distributions: website
+  - [x] IPFS distributions: website design
+  - [x] IPFS distributions: website landing page
+  - [x] IPFS distributions: website program listings
+  - [x] IPFS distributions: website domain (dist.ipfs.io)
+  - [ ] IPFS distributions: website localization
+- [x] IPFS distributions: tools
+  - [x] IPFS distributions: go-ipfs
+  - [x] IPFS distributions: ipfs-update
+  - [x] IPFS distributions: ipget
+  - [x] IPFS distributions: fs-repo-migrations
+  - [x] IPFS distributions: gx, gx-go
+  - [ ] IPFS distributions: station
+  - [ ] IPFS distributions: webui
 
-### Security
+## Security
 
 - [ ] Create a bug bounty program for IPFS
 - [ ] Have IPFS go and js implementations be fully Audited
 - [ ] Create a Security Working Group
 - [ ] Create a responsible disclosure program
 
-### IPFS Blog and Newsletter
+## IPFS blog and newsletter
 
 In order to keep the community updated, we run a blog. This blog is distributed through IPFS itself, and through an email newsletter.
 


### PR DESCRIPTION
Move the requirements (aka roadmap) and implementation status documents currently in the `ipfs/ipfs` repo into the docs, and update page links and side nav accordingly.

Disclaimer: This includes formatting for consistency, but not checking for updates and accuracy.

Ref https://github.com/ipfs/ipfs/pull/455