### PR TITLE
Adds deprecation message into all pages.

### DIFF
--- a/docs/.vuepress/theme/components/DeprecationNotice.vue
+++ b/docs/.vuepress/theme/components/DeprecationNotice.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="warning custom-block">
+    <p class="custom-block-title">This site will soon be leaving beta!</p>
+    <p>
+      The
+      <a target="_blank" href="//docs.ipfs.io"
+        >legacy IPFS documentation website</a
+      >
+      is being deprecated on 15th May, with this site replacing it. Links to
+      this page will redirect from <code>docs-beta.ipfs.io/</code> to
+      <code>docs.ipfs.io/</code>. This redirect with happen automatically, but
+      we just thought we'd let you know.
+    </p>
+  </div>
+</template>

--- a/docs/.vuepress/theme/components/DeprecationNotice.vue
+++ b/docs/.vuepress/theme/components/DeprecationNotice.vue
@@ -1,15 +1,15 @@
 <template>
-  <div class="warning custom-block">
-    <p class="custom-block-title">This site will soon be leaving beta!</p>
+  <div
+    class="warning custom-block"
+    style="margin: 2rem 2rem 0 2rem; max-width: calc(740px - 2.5rem);"
+  >
+    <p class="custom-block-title">THIS SITE LEAVES BETA MAY 15!</p>
     <p>
-      The
-      <a target="_blank" href="//docs.ipfs.io"
-        >legacy IPFS documentation website</a
-      >
-      is being deprecated on 15th May, with this site replacing it. Links to
-      this page will redirect from <code>docs-beta.ipfs.io/</code> to
-      <code>docs.ipfs.io/</code>. This redirect with happen automatically, but
-      we just thought we'd let you know.
+      On May 15, this site's content will permanently replace the
+      <a target="_blank" href="//docs.ipfs.io">old IPFS docs</a>. Pages on
+      <code>docs-beta.ipfs.io</code> will automatically redirect to
+      <code>docs.ipfs.io</code>, but you may want to update your own bookmarks
+      or links.
     </p>
   </div>
 </template>

--- a/docs/.vuepress/theme/components/DeprecationNotice.vue
+++ b/docs/.vuepress/theme/components/DeprecationNotice.vue
@@ -1,15 +1,23 @@
 <template>
-  <div
-    class="warning custom-block"
-    style="margin: 2rem 2rem 0 2rem; max-width: calc(740px - 2.5rem);"
-  >
-    <p class="custom-block-title">THIS SITE LEAVES BETA MAY 15!</p>
-    <p>
-      On May 15, this site's content will permanently replace the
-      <a target="_blank" href="//docs.ipfs.io">old IPFS docs</a>. Pages on
-      <code>docs-beta.ipfs.io</code> will automatically redirect to
-      <code>docs.ipfs.io</code>, but you may want to update your own bookmarks
-      or links.
-    </p>
+  <div class="theme-default-content">
+    <div id="notice" class="warning custom-block">
+      <p class="custom-block-title">🚀 Beta -> Launch</p>
+      <p>
+        <strong>On May 15</strong>, this site's content will replace the
+        <a target="_blank" href="//docs.ipfs.io">old IPFS docs</a>. Pages on
+        <code>docs-beta.ipfs.io</code> will automatically redirect to
+        <code>docs.ipfs.io</code>, but you may want to update your own bookmarks
+        or links.
+      </p>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.theme-default-content {
+  padding-bottom: 0;
+}
+#notice {
+  margin: 0;
+}
+</style>

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -2,6 +2,8 @@
   <main class="page">
     <slot name="top" />
 
+    <DeprecationNotice />
+
     <Content class="theme-default-content" />
 
     <div class="content-footer" v-if="!isContentStatus">
@@ -27,6 +29,7 @@ import PageEdit from '@parent-theme/components/PageEdit.vue'
 import PageNav from '@parent-theme/components/PageNav.vue'
 
 import Feedback from './Feedback.vue'
+import DeprecationNotice from './DeprecationNotice.vue'
 import LegacyCallout from './LegacyCallout.vue'
 import Analytics from './Analytics.vue'
 import ScrollPatch from './ScrollPatch.vue'
@@ -37,18 +40,19 @@ export default {
     PageEdit,
     PageNav,
     Feedback,
+    DeprecationNotice,
     LegacyCallout,
     Analytics,
     ScrollPatch
   },
   props: ['sidebarItems'],
   computed: {
-    isContentStatus: function() {
+    isContentStatus: function () {
       return !!(this.$frontmatter && this.$frontmatter.issueUrl)
     }
   },
   methods: {
-    smoothScroll: function() {
+    smoothScroll: function () {
       var root = document.getElementsByTagName('html')[0]
       // only enable smooth-scrolling on pages shorter that 15000 px
       return root.scrollHeight < 15000
@@ -56,10 +60,10 @@ export default {
         : root.classList.remove('smooth-scroll')
     }
   },
-  mounted: function() {
+  mounted: function () {
     this.smoothScroll()
   },
-  updated: function() {
+  updated: function () {
     this.smoothScroll()
   }
 }

--- a/docs/.vuepress/theme/global-components/ContentStatus.vue
+++ b/docs/.vuepress/theme/global-components/ContentStatus.vue
@@ -4,6 +4,7 @@
       <div class="illustration">
         <img src="../assets/pencil-rocket.svg" />
       </div>
+
       <h2>{{ title }}</h2>
       <div v-if="issueUrl" class="content-status-status">
         <a target="_blank" :href="issueUrl">Check the status</a>
@@ -34,7 +35,7 @@
       </div>
     </div>
 
-    <div class="content-status-info" style="clear: both">
+    <div class="content-status-info" style="clear: both;">
       <div v-if="related" class="section content-other-resources">
         <h3>Other resources to try</h3>
         <ul>
@@ -57,15 +58,15 @@ import Feedback from '../components/Feedback.vue'
 
 export default {
   computed: {
-    issueUrl: function() {
+    issueUrl: function () {
       return this.$frontmatter && this.$frontmatter.issueUrl
     },
-    repo: function() {
+    repo: function () {
       return (
         this.$site && this.$site.themeConfig && this.$site.themeConfig.docsRepo
       )
     },
-    related: function() {
+    related: function () {
       return this.$frontmatter.related
     }
   },


### PR DESCRIPTION
Adds a deprecation notice to the top of every page, but it doesn't look great. Can't figure out how to get the warning message into the `content__default` div. 

![image](https://user-images.githubusercontent.com/9611008/81019553-e6cf2480-8e34-11ea-9156-e1a94b2d8ffb.png)

@cwaring or @jessicaschilling, any ideas of how to throw it in there? I don't really want to spend more than 10 minutes on this if I can help it.

### [Preview here](https://bafybeifk2fs6ws7osll5xcb4j2faokwotgfs6j2qghi2mwjmynu6bjfdsi.ipfs.dweb.link/).